### PR TITLE
Refacor(*): CI push 이벤트 main 브랜치로만 실행되도록 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, develop]
   push:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] push 이벤트 main 브랜치로만 실행되도록 변경

`on:
  pull_request:
    branches: [main, develop]
  push:
    branches: [main, develop]`
-> 다음과 같이 수정
`on:
  pull_request:
    branches: [main, develop]
  push:
    branches: [main]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 푸시 이벤트에 대한 워크플로우가 이제 `main` 브랜치에서만 실행되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->