### PR TITLE
Refactor(design-system): 버튼 rem 값 수정, outline 버튼 컬러 미적용 문제 해결 / 폰트 관련 문제 공유 

### DIFF
--- a/packages/design-system/src/components/button/Button.stories.tsx
+++ b/packages/design-system/src/components/button/Button.stories.tsx
@@ -6,6 +6,7 @@ import Button from './Button';
 const meta: Meta<typeof Button> = {
   title: 'components/Button',
   component: Button,
+  tags: ['autodocs'],
   argTypes: {
     variant: { control: 'radio', options: ['filled', 'outline', 'text'] },
     color: {

--- a/packages/design-system/src/components/button/Button.tsx
+++ b/packages/design-system/src/components/button/Button.tsx
@@ -13,7 +13,7 @@ interface ButtonProps
   size: 'lg' | 'md' | 'sm';
 }
 
-const baseButtonStyle = 'px-[2rem] py-[0.62rem] gap-[0.5rem]';
+const baseButtonStyle = 'px-[3.2rem] py-[1rem] gap-[0.8rem]';
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center font-bold',
@@ -29,13 +29,13 @@ const buttonVariants = cva(
         secondary: '',
       },
       rounded: {
-        true: 'rounded-[0.5rem]',
+        true: 'rounded-[0.8rem]',
         false: '',
       },
       size: {
-        lg: `h-[3.75rem] ${baseButtonStyle}`,
-        md: `h-[3.25rem] ${baseButtonStyle}`,
-        sm: `h-[2rem] px-[1.5rem] py-[0.62rem] gap-[0.5rem]`,
+        lg: `h-[6rem] ${baseButtonStyle}`,
+        md: `h-[5.2rem] ${baseButtonStyle}`,
+        sm: `h-[3.2rem] px-[1.6rem] py-[1rem] gap-[0.8rem]`,
       },
     },
     compoundVariants: [

--- a/packages/design-system/src/components/button/Button.tsx
+++ b/packages/design-system/src/components/button/Button.tsx
@@ -7,9 +7,9 @@ interface ButtonProps
     VariantProps<typeof buttonVariants> {
   iconLeft?: ReactNode;
   iconRight?: ReactNode;
+  rounded?: boolean;
   color: 'primary' | 'secondary';
   variant: 'filled' | 'outline' | 'text';
-  rounded?: boolean;
   size: 'lg' | 'md' | 'sm';
 }
 
@@ -27,7 +27,6 @@ const buttonVariants = cva(
       color: {
         primary: '',
         secondary: '',
-        default: '',
       },
       rounded: {
         true: 'rounded-[0.5rem]',
@@ -87,12 +86,10 @@ export default function Button({
   rounded = false,
   ...props
 }: ButtonProps) {
-  const outlineColor = variant === 'outline' ? 'default' : color;
-
   return (
     <button
       className={cn(
-        buttonVariants({ variant, color: outlineColor, size, rounded }),
+        buttonVariants({ variant, color, size, rounded }),
         className
       )}
       {...props}

--- a/packages/design-system/src/components/button/index.ts
+++ b/packages/design-system/src/components/button/index.ts
@@ -1,1 +1,1 @@
-export * from './Button';
+export { default as Button } from './Button';


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #43 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

- [X] 1rem 당 16px -> 10px 기준으로 수정
- [X] outline 버튼 컬러 미적용 문제 로직 수정 

## To Reviewer

- 큰 로직 변화는 없고 rem 단위 수정이나 불필요한 로직 제거 작업 진행했습니다.

- 추가적으로 공유할 문제를 발견했는데요! 테스트로 className에 폰트까지 넣어서 적용해봤는데, 폰트 적용은 잘 되지만 텍스트 컬러가 black으로 덮어지는 문제가 있습니다.
- 원인을 찾아보니 색상(ex: .text-pink-500)과 저희가 지정한 폰트 사이즈 유틸(ex: .text-jp-body2)이 둘 다 "text-" 그룹에 묶이다 보니 충돌해서, .text-jp-body2가 기본 텍스트 컬러를 초기값(black)으로 덮어져 버린 것이더라구요🥺
 제가 임의로 테스트할 때는 유틸 클래스 네이밍을 변경해줌으로써 해결했습니다!
예로 들면, text-jp-body2 → font-jp-body2 처럼 text-를 제거해서 유틸 색상과 구분해주었어요. 이렇게 변경하니 폰트 및 컬러까지 잘 적용이 되었습니다. 스타일 관련이다보니 팀원분들과 논의가 필요할 것 같아 스타일 파일(shared-styles.css)을 수정하지는 않았어요! 다른 해결 방법이 있거나 의견 있으시다면 공유해주시면 좋을 것 같아요~ :)!

<img width="590" alt="image" src="https://github.com/user-attachments/assets/bdfe6021-1f04-4bb2-ad1e-8bf0f6a4c601" />

## Screenshot

💡 로컬 환경입니당(outline 버튼 컬러 적용됨)

https://github.com/user-attachments/assets/3fb0f61e-3609-4905-9387-36d1eeb4b195




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Style**
  * 버튼의 크기, 여백, 간격, 라운드 스타일이 전체적으로 더 커지고 둥글게 변경되었습니다.

* **Refactor**
  * 버튼 컴포넌트의 색상 처리 방식이 단순화되었습니다.
  * 버튼 컴포넌트의 내보내기(export) 방식이 명확하게 변경되었습니다.

* **Documentation**
  * 버튼 스토리북 메타데이터에 자동 문서화 태그가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->