### PR TITLE
Refactor(*): OpenAPI 스펙 버전 3.1.0 → 3.0.1 하향 조정

### DIFF
--- a/apps/web/api/Product.ts
+++ b/apps/web/api/Product.ts
@@ -10,12 +10,84 @@
  * ---------------------------------------------------------------
  */
 
-import { ApiResponseCategoryProductResponse } from "./data-contracts";
+import {
+  ApiResponseCategoryNewProductResponse,
+  ApiResponseCategoryPopularProductResponse,
+  ApiResponseNameBrandProductResponse,
+  ApiResponseObject,
+  ApiResponseProductDetailResponse,
+  ApiResponseProductDetailYoutubeResponse,
+  ProductSearchRequest,
+} from "./data-contracts";
 import { HttpClient, RequestParams } from "./http-client";
 
 export class Product<
   SecurityDataType = unknown,
 > extends HttpClient<SecurityDataType> {
+  /**
+   * No description
+   *
+   * @tags PRODUCT
+   * @name Search
+   * @summary 상품명 또는 브랜드명 상품 검색
+   * @request GET:/api/products/search
+   * @secure
+   */
+  search = (
+    query: {
+      request: ProductSearchRequest;
+      /**
+       * @format int32
+       * @default 0
+       */
+      page?: number;
+      /**
+       * @format int32
+       * @default 20
+       */
+      size?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<ApiResponseNameBrandProductResponse, any>({
+      path: `/api/products/search`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * No description
+   *
+   * @tags PRODUCT
+   * @name GetProductDetail
+   * @summary 상세조회 제품(별점 포함) 조회
+   * @request GET:/api/products/details/{productId}
+   * @secure
+   */
+  getProductDetail = (productId: number, params: RequestParams = {}) =>
+    this.request<ApiResponseProductDetailResponse, any>({
+      path: `/api/products/details/${productId}`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * No description
+   *
+   * @tags PRODUCT
+   * @name GetProductDetailYoutube
+   * @summary 상세조회 유튜브 리뷰 조회
+   * @request GET:/api/products/details/{productId}/youtube
+   * @secure
+   */
+  getProductDetailYoutube = (productId: number, params: RequestParams = {}) =>
+    this.request<ApiResponseProductDetailYoutubeResponse, any>({
+      path: `/api/products/details/${productId}/youtube`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
   /**
    * No description
    *
@@ -27,13 +99,115 @@ export class Product<
    */
   searchProductsByCategory = (
     query: {
-      middleCategoryId: string;
-      subCategoryId?: string;
+      middleCategory:
+        | "FACIAL_CARE"
+        | "FACE_MAKEUP"
+        | "EYE_MAKEUP"
+        | "LIP_MAKEUP";
+      subCategory?:
+        | "TONER"
+        | "MOISTURIZER"
+        | "ESSENCE_SERUM"
+        | "CREAM"
+        | "FOUNDATION"
+        | "POWDER_COMPACT"
+        | "CONCEALER"
+        | "BLUSHER"
+        | "EYEBROW"
+        | "EYESHADOW"
+        | "EYELINER"
+        | "LIPSTICK"
+        | "LIP_TINT";
+      /** @default "false" */
+      searchType?: "PRODUCT" | "REVIEW";
+      mediaType?: "IMAGE" | "VIDEO";
+      /**
+       * @format int32
+       * @default 0
+       */
+      page?: number;
+      /**
+       * @format int32
+       * @default 20
+       */
+      size?: number;
     },
     params: RequestParams = {},
   ) =>
-    this.request<ApiResponseCategoryProductResponse, any>({
+    this.request<ApiResponseObject, any>({
       path: `/api/products/categories/search`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * No description
+   *
+   * @tags PRODUCT
+   * @name SearchPopularProductsByCategory
+   * @summary 인기상품 카테고리별 조회
+   * @request GET:/api/products/categories/popular
+   * @secure
+   */
+  searchPopularProductsByCategory = (
+    query: {
+      middleCategory:
+        | "FACIAL_CARE"
+        | "FACE_MAKEUP"
+        | "EYE_MAKEUP"
+        | "LIP_MAKEUP";
+      /**
+       * @format int32
+       * @default 0
+       */
+      page?: number;
+      /**
+       * @format int32
+       * @default 20
+       */
+      size?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<ApiResponseCategoryPopularProductResponse, any>({
+      path: `/api/products/categories/popular`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * No description
+   *
+   * @tags PRODUCT
+   * @name SearchNewProductsByCategory
+   * @summary 신상품 카테고리별 조회
+   * @request GET:/api/products/categories/new
+   * @secure
+   */
+  searchNewProductsByCategory = (
+    query: {
+      middleCategory:
+        | "FACIAL_CARE"
+        | "FACE_MAKEUP"
+        | "EYE_MAKEUP"
+        | "LIP_MAKEUP";
+      /**
+       * @format int32
+       * @default 0
+       */
+      page?: number;
+      /**
+       * @format int32
+       * @default 20
+       */
+      size?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<ApiResponseCategoryNewProductResponse, any>({
+      path: `/api/products/categories/new`,
       method: "GET",
       query: query,
       secure: true,

--- a/apps/web/api/data-contracts.ts
+++ b/apps/web/api/data-contracts.ts
@@ -40,31 +40,132 @@ export interface VideoResponse {
   uploadedAt?: string;
 }
 
-export interface ApiResponseCategoryProductResponse {
+export interface ProductSearchRequest {
+  /**
+   * @minLength 0
+   * @maxLength 20
+   */
+  keyword: string;
+}
+
+export interface ApiResponseNameBrandProductResponse {
   success?: boolean;
   /** @format int32 */
   status?: number;
   message?: string;
-  data?: CategoryProductResponse;
+  data?: NameBrandProductResponse;
 }
 
-export interface CategoryProductResponse {
+export interface NameBrandProductResponse {
   searchQuery?: string;
-  mainCategory?: string;
-  subCategory?: string;
-  /** @format int32 */
-  resultCount?: number;
   products?: ProductResponse[];
+  pageInfo?: PageableResponse;
+}
+
+export interface PageableResponse {
+  /** @format int32 */
+  pageNumber?: number;
+  /** @format int32 */
+  pageSize?: number;
+  /** @format int32 */
+  numberOfElements?: number;
+  isLast?: boolean;
 }
 
 export interface ProductResponse {
   /** @format int64 */
   productId?: number;
-  imageUrl?: string;
+  imageUrls?: string[];
   productName?: string;
+  brandName?: string;
+  unit?: string;
   /** @format int64 */
   reviewCount?: number;
+  /** @format double */
   rating?: number;
+}
+
+export interface ApiResponseProductDetailResponse {
+  success?: boolean;
+  /** @format int32 */
+  status?: number;
+  message?: string;
+  data?: ProductDetailResponse;
+}
+
+export interface ProductDetailResponse {
+  products?: ProductResponse[];
+  productOptions?: string[];
+  /** @format int64 */
+  normalPrice?: number;
+  productDetail?: string;
+  ingredients?: string;
+  shippingInfo?: string;
+  oliveYoungUrl?: string;
+  q10Url?: string;
+  middleCategory?: "FACIAL_CARE" | "FACE_MAKEUP" | "EYE_MAKEUP" | "LIP_MAKEUP";
+  subCategory?:
+    | "TONER"
+    | "MOISTURIZER"
+    | "ESSENCE_SERUM"
+    | "CREAM"
+    | "FOUNDATION"
+    | "POWDER_COMPACT"
+    | "CONCEALER"
+    | "BLUSHER"
+    | "EYEBROW"
+    | "EYESHADOW"
+    | "EYELINER"
+    | "LIPSTICK"
+    | "LIP_TINT";
+}
+
+export interface ApiResponseProductDetailYoutubeResponse {
+  success?: boolean;
+  /** @format int32 */
+  status?: number;
+  message?: string;
+  data?: ProductDetailYoutubeResponse;
+}
+
+export interface ProductDetailYoutubeResponse {
+  youtubeUrls?: string[];
+}
+
+export interface ApiResponseObject {
+  success?: boolean;
+  /** @format int32 */
+  status?: number;
+  message?: string;
+  data?: any;
+}
+
+export interface ApiResponseCategoryPopularProductResponse {
+  success?: boolean;
+  /** @format int32 */
+  status?: number;
+  message?: string;
+  data?: CategoryPopularProductResponse;
+}
+
+export interface CategoryPopularProductResponse {
+  searchQuery?: string;
+  products?: ProductResponse[];
+  pageInfo?: PageableResponse;
+}
+
+export interface ApiResponseCategoryNewProductResponse {
+  success?: boolean;
+  /** @format int32 */
+  status?: number;
+  message?: string;
+  data?: CategoryNewProductResponse;
+}
+
+export interface CategoryNewProductResponse {
+  searchQuery?: string;
+  products?: ProductResponse[];
+  pageInfo?: PageableResponse;
 }
 
 export interface ApiResponseLineLoginResponse {

--- a/apps/web/api/http-client.ts
+++ b/apps/web/api/http-client.ts
@@ -11,9 +11,9 @@
  */
 
 export type QueryParamsType = Record<string | number, any>;
-export type ResponseFormat = keyof Omit<Body, 'body' | 'bodyUsed'>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
-export interface FullRequestParams extends Omit<RequestInit, 'body'> {
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
   /** set parameter to `true` for call `securityWorker` for this request */
   secure?: boolean;
   /** request path */
@@ -34,14 +34,14 @@ export interface FullRequestParams extends Omit<RequestInit, 'body'> {
 
 export type RequestParams = Omit<
   FullRequestParams,
-  'body' | 'method' | 'query' | 'path'
+  "body" | "method" | "query" | "path"
 >;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
-  baseApiParams?: Omit<RequestParams, 'baseUrl' | 'cancelToken' | 'signal'>;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
   securityWorker?: (
-    securityData: SecurityDataType | null
+    securityData: SecurityDataType | null,
   ) => Promise<RequestParams | void> | RequestParams | void;
   customFetch?: typeof fetch;
 }
@@ -55,27 +55,26 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown>
 type CancelToken = Symbol | string | number;
 
 export enum ContentType {
-  Json = 'application/json',
-  JsonApi = 'application/vnd.api+json',
-  FormData = 'multipart/form-data',
-  UrlEncoded = 'application/x-www-form-urlencoded',
-  Text = 'text/plain',
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string =
-    process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000';
+  public baseUrl: string = "/";
   private securityData: SecurityDataType | null = null;
-  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
   private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
     fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
-    credentials: 'same-origin',
+    credentials: "same-origin",
     headers: {},
-    redirect: 'follow',
-    referrerPolicy: 'no-referrer',
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
   };
 
   constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
@@ -88,7 +87,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected encodeQueryParam(key: string, value: any) {
     const encodedKey = encodeURIComponent(key);
-    return `${encodedKey}=${encodeURIComponent(typeof value === 'number' ? value : `${value}`)}`;
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
   }
 
   protected addQueryParam(query: QueryParamsType, key: string) {
@@ -97,39 +96,39 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key];
-    return value.map((v: any) => this.encodeQueryParam(key, v)).join('&');
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
   }
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
     const keys = Object.keys(query).filter(
-      (key) => 'undefined' !== typeof query[key]
+      (key) => "undefined" !== typeof query[key],
     );
     return keys
       .map((key) =>
         Array.isArray(query[key])
           ? this.addArrayQueryParam(query, key)
-          : this.addQueryParam(query, key)
+          : this.addQueryParam(query, key),
       )
-      .join('&');
+      .join("&");
   }
 
   protected addQueryParams(rawQuery?: QueryParamsType): string {
     const queryString = this.toQueryString(rawQuery);
-    return queryString ? `?${queryString}` : '';
+    return queryString ? `?${queryString}` : "";
   }
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.JsonApi]: (input: any) =>
-      input !== null && (typeof input === 'object' || typeof input === 'string')
+      input !== null && (typeof input === "object" || typeof input === "string")
         ? JSON.stringify(input)
         : input,
     [ContentType.Text]: (input: any) =>
-      input !== null && typeof input !== 'string'
+      input !== null && typeof input !== "string"
         ? JSON.stringify(input)
         : input,
     [ContentType.FormData]: (input: any) =>
@@ -139,9 +138,9 @@ export class HttpClient<SecurityDataType = unknown> {
           key,
           property instanceof Blob
             ? property
-            : typeof property === 'object' && property !== null
+            : typeof property === "object" && property !== null
               ? JSON.stringify(property)
-              : `${property}`
+              : `${property}`,
         );
         return formData;
       }, new FormData()),
@@ -150,7 +149,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected mergeRequestParams(
     params1: RequestParams,
-    params2?: RequestParams
+    params2?: RequestParams,
   ): RequestParams {
     return {
       ...this.baseApiParams,
@@ -165,7 +164,7 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected createAbortSignal = (
-    cancelToken: CancelToken
+    cancelToken: CancelToken,
   ): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
       const abortController = this.abortControllers.get(cancelToken);
@@ -201,7 +200,7 @@ export class HttpClient<SecurityDataType = unknown> {
     ...params
   }: FullRequestParams): Promise<HttpResponse<T, E>> => {
     const secureParams =
-      ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) &&
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
         this.securityWorker &&
         (await this.securityWorker(this.securityData))) ||
       {};
@@ -211,13 +210,13 @@ export class HttpClient<SecurityDataType = unknown> {
     const responseFormat = format || requestParams.format;
 
     return this.customFetch(
-      `${baseUrl || this.baseUrl || ''}${path}${queryString ? `?${queryString}` : ''}`,
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
       {
         ...requestParams,
         headers: {
           ...(requestParams.headers || {}),
           ...(type && type !== ContentType.FormData
-            ? { 'Content-Type': type }
+            ? { "Content-Type": type }
             : {}),
         },
         signal:
@@ -225,10 +224,10 @@ export class HttpClient<SecurityDataType = unknown> {
             ? this.createAbortSignal(cancelToken)
             : requestParams.signal) || null,
         body:
-          typeof body === 'undefined' || body === null
+          typeof body === "undefined" || body === null
             ? null
             : payloadFormatter(body),
-      }
+      },
     ).then(async (response) => {
       const r = response.clone() as HttpResponse<T, E>;
       r.data = null as unknown as T;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
     "deploy:web": "turbo run deploy --scope='web'",
-    "generate:api:web": "dotenv -e .env -- swagger-typescript-api generate -p $SWAGGERI_URL -o ./apps/web/api --modular --clean-output --module-name-first-tag"
+    "generate:api:web": "dotenv -e .env -- sh -lc 'curl -s \"$SWAGGERI_URL\" | sed \"s/\\\"openapi\\\":\\\"3\\.1\\.0\\\"/\\\"openapi\\\":\\\"3.0.1\\\"/\" > ./tmp-spec.json && swagger-typescript-api generate -p ./tmp-spec.json -o ./apps/web/api --modular --clean-output --module-name-first-tag && rm ./tmp-spec.json'"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #79 

OpenAPI 3.1.0 스펙을 지원하지 않는 swagger2openapi@7.x 문제를 해결을 위해 코드 생성 스크립트(generate:api:web)를 수정했습니다. 백엔드분들이 사용하신 "openapi":"3.1.0"을 "3.0.1"로 변경한 뒤 임시 파일(tmp-spec.json)로 저장하고, 이 파일을 입력으로 사용해 정상적으로 TypeScript 클라이언트를 생성하도록 했습니다. 최종적으로 임시파일은 자동 삭제 됩니다!

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] package.json의 generate:api:web 스크립트 수정
  - curl로 $SWAGGERI_URL JSON 다운로드
  - sed를 이용해 "openapi":"3.1.0"→"openapi":"3.0.1" 변경
  - 변경된 결과를 tmp-spec.json으로 저장
  - swagger-typescript-api에 -p ./tmp-spec.json 옵션으로 전달하여 코드 생성
  - 생성 완료 후 tmp-spec.json 자동 삭제
  - `"generate:api:web": "dotenv -e .env -- sh -lc 'curl -s \"$SWAGGERI_URL\" | sed \"s/\\\"openapi\\\":\\\"3\\.1\\.0\\\"/\\\"openapi\\\":\\\"3.0.1\\\"/\" > ./tmp-spec.json && swagger-typescript-api generate -p ./tmp-spec.json -o ./apps/web/api --modular --clean-output --module-name-first-tag && rm ./tmp-spec.json'"`
- [X] pnpm generate:api:web 실행하여
  - data-contracts.ts, http-client.ts, 태그별 API 파일 등이 정상 생성되는지 확인

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot
<img width="656" alt="image" src="https://github.com/user-attachments/assets/d3a71560-90c0-4578-875f-166ac0303e07" />

<img width="201" alt="스크린샷 2025-07-09 오후 7 44 36" src="https://github.com/user-attachments/assets/9420c2ed-d1ed-436c-b2d8-fb4cbe4e9137" />

