### PR TITLE
Bug(*): 타이포 토큰 적용 오류 수정

### DIFF
--- a/apps/web/components/card/card-products.tsx
+++ b/apps/web/components/card/card-products.tsx
@@ -60,7 +60,7 @@ export default function CardProduct({
         {ranking && <Badge rank={ranking} />}
       </div>
       <div className="flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-dashed border-pink-500">
-        <p className="text-jp-body1 font-[700]">{brandName}</p>
+        <p className="jp-body1 font-[700]">{brandName}</p>
         <div>
           {isLiked ? (
             <SvgLikeFill size={24} className="fill-pink-500" />
@@ -70,9 +70,9 @@ export default function CardProduct({
         </div>
       </div>
       <div className="flex h-[4.4rem] items-center border-b-[0.1rem] border-dashed border-pink-500">
-        <p className="text-jp-body2 font-[500]">{productName}</p>
+        <p className="jp-body2 font-[500]">{productName}</p>
       </div>
-      <div className="text-en-caption1 flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-pink-500 text-gray-600">
+      <div className="en-caption1 flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-pink-500 text-gray-600">
         <p>{unit}</p>
         <div className="flex items-center">
           <SvgStar size={16} className="fill-yellow" />

--- a/apps/web/components/card/card-review.tsx
+++ b/apps/web/components/card/card-review.tsx
@@ -77,12 +77,12 @@ export default function CardReview({
         {ranking && <Badge rank={ranking} />}
         <div className="absolute bottom-0 left-0 right-0 flex flex-col gap-[0.8rem] p-[2.56rem_2.56rem_1.92rem]">
           <div>
-            <p className="text-en-title2 font-[700] text-white">{brandName}</p>
-            <p className="text-jp-body2 font-[500] text-white">{productName}</p>
+            <p className="en-title2 font-[700] text-white">{brandName}</p>
+            <p className="jp-body2 font-[500] text-white">{productName}</p>
           </div>
           <div className="flex items-center gap-[0.8rem]">
             <SvgGoodFill size={24} className="fill-white" />
-            <p className="text-en-body1 font-[500] text-white">{likeCount}</p>
+            <p className="en-body1 font-[500] text-white">{likeCount}</p>
           </div>
         </div>
       </div>

--- a/apps/web/components/footer/footer.tsx
+++ b/apps/web/components/footer/footer.tsx
@@ -57,8 +57,8 @@ function FooterLeft({ title, desc }: Pick<FooterProps, 'title' | 'desc'>) {
   return (
     <div className="flex w-[45.6rem] flex-col items-start gap-[5.6rem] bg-pink-100">
       <div className="flex flex-col items-start gap-[2.4rem] self-stretch">
-        <p className="text-en-title3 font-bold leading-loose">{title}</p>
-        <p className="text-jp-body2 font-medium text-zinc-600">{desc}</p>
+        <p className="en-title3 font-bold leading-loose">{title}</p>
+        <p className="jp-body2 font-medium text-gray-600">{desc}</p>
       </div>
       <div className="flex items-center gap-[0.8rem]">
         <Link
@@ -84,7 +84,7 @@ function FooterLeft({ title, desc }: Pick<FooterProps, 'title' | 'desc'>) {
 
 function FooterBottom({ copyright }: Pick<FooterProps, 'copyright'>) {
   return (
-    <p className="text-en-body1 bg-pink-100 font-medium text-pink-500">
+    <p className="en-body1 bg-pink-100 font-medium text-pink-500">
       {copyright}
     </p>
   );
@@ -98,7 +98,7 @@ function FooterRight({ menu }: Pick<FooterProps, 'menu'>) {
           key={title}
           className="flex w-[16.8rem] flex-col items-start gap-[2.4rem]"
         >
-          <p className="text-jp-body1 font-bold">{title}</p>
+          <p className="jp-body1 font-bold">{title}</p>
           <div className="flex flex-col items-start justify-start gap-[0.8rem] self-stretch">
             {option.map((item) => (
               <Link
@@ -106,7 +106,7 @@ function FooterRight({ menu }: Pick<FooterProps, 'menu'>) {
                 key={item}
                 className="flex h-[3.2rem] items-center gap-[0.8rem] self-stretch py-[1rem]"
               >
-                <p className="text-jp-body2 font-medium">{item}</p>
+                <p className="jp-body2 font-medium">{item}</p>
                 <SvgArrowRight />
               </Link>
             ))}

--- a/apps/web/components/header/header.tsx
+++ b/apps/web/components/header/header.tsx
@@ -157,7 +157,7 @@ function Gnb({
             >
               <p
                 className={cn(
-                  'text-jp-title2 flex h-full items-center gap-[1rem] whitespace-nowrap px-[3.2rem] pb-[1rem] pt-[1rem] font-bold',
+                  'jp-title2 flex h-full items-center gap-[1rem] whitespace-nowrap px-[3.2rem] pb-[1rem] pt-[1rem] font-bold',
                   isActive ? 'text-pink-500' : 'text-gray-800'
                 )}
               >
@@ -195,7 +195,7 @@ function MegaMenu({
           >
             <button
               className={cn(
-                'text-jp-body2 cursor-pointer whitespace-nowrap px-[2.4rem] py-[1rem]',
+                'jp-body2 cursor-pointer whitespace-nowrap px-[2.4rem] py-[1rem]',
                 isActive ? 'font-bold text-pink-500' : 'text-gray-600'
               )}
               onClick={() => handleSelectOption(option)}
@@ -218,7 +218,7 @@ function SearchBar({ searchValue, handleChangeSearch }: SearchProps) {
         value={searchValue}
         onChange={(e) => handleChangeSearch(e.target.value)}
         placeholder="ラネージュ"
-        className="text-jp-body2 w-full text-right font-bold leading-[3rem] text-gray-800"
+        className="jp-body2 w-full text-right font-bold leading-[3rem] text-gray-800"
       />
       <div className="flex h-[6.4rem] w-[6.4rem] shrink-0 cursor-pointer items-center justify-center p-[1.4rem]">
         <SvgSearch className="cursor-pointer" />

--- a/packages/design-system/src/components/badge/Badge.tsx
+++ b/packages/design-system/src/components/badge/Badge.tsx
@@ -9,7 +9,7 @@ interface BadgeProps {
 const OTHER_RANK_STYLE = `border-b-[0.1rem] border-r-[0.1rem] border-pink-500 bg-pink-100 text-pink-500`;
 
 const badgeVariants = cva(
-  `text-en-title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 z-50`,
+  `en-title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 z-50`,
   {
     variants: {
       variant: {

--- a/packages/design-system/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/design-system/src/components/breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'text-jp-body2 flex flex-wrap items-center gap-1.5 break-words sm:gap-2.5',
+        'jp-body2 flex flex-wrap items-center gap-1.5 break-words sm:gap-2.5',
         className
       )}
       {...props}

--- a/packages/design-system/src/components/error-notice/ErrorNotice.tsx
+++ b/packages/design-system/src/components/error-notice/ErrorNotice.tsx
@@ -10,7 +10,7 @@ export default function ErrorNotice({ message, className }: ErrorNoticeProps) {
   return (
     <p
       className={cn(
-        'text-jp-caption3 mt-[0.8rem] flex items-center text-[color:var(--color-red)]',
+        'jp-caption3 mt-[0.8rem] flex items-center text-[color:var(--color-red)]',
         className
       )}
     >

--- a/packages/design-system/src/components/input/Input.tsx
+++ b/packages/design-system/src/components/input/Input.tsx
@@ -10,8 +10,8 @@ const inputVariants = cva('w-[40.8rem] focus:outline-none', {
   variants: {
     type: {
       default:
-        'h-[5.2rem] border-b border-b-gray-400 text-jp-body2 hover:border-b-pink-500 focus:border-b-pink-500',
-      search: 'h-[6.4rem] text-right text-jp-title1 font-bold focus:bg-gray-50',
+        'h-[5.2rem] border-b border-b-gray-400 jp-body2 hover:border-b-pink-500 focus:border-b-pink-500',
+      search: 'h-[6.4rem] text-right jp-title1 font-bold focus:bg-gray-50',
     },
   },
   defaultVariants: {

--- a/packages/design-system/src/components/tab/Tab.tsx
+++ b/packages/design-system/src/components/tab/Tab.tsx
@@ -20,8 +20,8 @@ const tabVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'h-11 text-jp-title3  text-gray-500 leading-normal',
-        secondary: 'h-14 text-jp-title2  text-gray-800 leading-relaxed',
+        primary: 'h-11 jp-title3  text-gray-500 leading-normal',
+        secondary: 'h-14 jp-title2  text-gray-800 leading-relaxed',
       },
       active: {
         true: 'border-b-2 border-solid',

--- a/packages/design-system/src/components/tag/Tag.tsx
+++ b/packages/design-system/src/components/tag/Tag.tsx
@@ -6,7 +6,7 @@ interface TagProps {
 
 export default function Tag({ text }: TagProps) {
   return (
-    <div className="text-jp-caption1 inline-flex items-center justify-center gap-[0.4rem] rounded-[0.4rem] bg-gray-100 px-[0.8rem] py-[0.45rem] font-[500] text-gray-800">
+    <div className="jp-caption1 inline-flex items-center justify-center gap-[0.4rem] rounded-[0.4rem] bg-gray-100 px-[0.8rem] py-[0.45rem] font-[500] text-gray-800">
       <SvgCheckNonBg className="fill-green" size={20} />
       <p>{text}</p>
     </div>

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -30,11 +30,6 @@
   --color-green: #15c37e;
   --color-blue: #3182f7;
 
-  /* font-weight */
-  --font-bold: 700;
-  --font-medium: 500;
-  --font-regular: 400;
-
   /* JP head */
   --text-jp-head1: 3.2rem;
   --text-jp-head2: 2.8rem;
@@ -83,106 +78,106 @@
 
 @layer utilities {
   /* 커스텀 유틸리티 클래스 */
-  .text-jp-head1 {
+  .jp-head1 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-head1);
     line-height: 140%;
   }
-  .text-jp-head2 {
+  .jp-head2 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-head2);
     line-height: 140%;
   }
-  .text-jp-head3 {
+  .jp-head3 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-head3);
     line-height: 150%;
   }
 
   /* JP Title */
-  .text-jp-title1 {
+  .jp-title1 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-title1);
     line-height: 150%;
   }
-  .text-jp-title2 {
+  .jp-title2 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-title2);
     line-height: 150%;
   }
-  .text-jp-title3 {
+  .jp-title3 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-title3);
     line-height: 150%;
   }
 
   /* JP Body */
-  .text-jp-body1 {
+  .jp-body1 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-body1);
     line-height: 160%;
   }
-  .text-jp-body2 {
+  .jp-body2 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-body2);
     line-height: 160%;
   }
 
   /* JP Caption */
-  .text-jp-caption1 {
+  .jp-caption1 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-caption1);
     line-height: 160%;
   }
-  .text-jp-caption2 {
+  .jp-caption2 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-caption2);
     line-height: 160%;
   }
-  .text-jp-caption3 {
+  .jp-caption3 {
     font-family: var(--font-noto-sans-jp);
     font-size: var(--text-jp-caption3);
     line-height: 160%;
   }
 
   /* EN Heading */
-  .text-en-head1 {
+  .en-head1 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-head1);
     line-height: 150%;
   }
 
   /* EN Title */
-  .text-en-title1 {
+  .en-title1 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-title1);
     line-height: 150%;
   }
-  .text-en-title2 {
+  .en-title2 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-title2);
     line-height: 150%;
   }
-  .text-en-title3 {
+  .en-title3 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-title3);
     line-height: 150%;
   }
 
   /* EN Body */
-  .text-en-body1 {
+  .en-body1 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-body1);
     line-height: 100%;
   }
-  .text-en-body2 {
+  .en-body2 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-body2);
     line-height: 100%;
   }
 
   /* EN Caption */
-  .text-en-caption1 {
+  .en-caption1 {
     font-family: var(--font-pretendard);
     font-size: var(--text-en-caption1);
     line-height: 150%;


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #83 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->
타이포 토큰이랑 weight가 같이 적용되지 않던 문제를 수정했어요.

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] 타이포 토큰명 변경

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
머지되면 작업 중인 브랜치에서 한 번 땡기고 사용해주세요......................

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 모든 타이포그래피 관련 CSS 클래스에서 "text-" 접두사가 제거되어 클래스명이 간소화되었습니다. (예: text-jp-body1 → jp-body1)
  * 일부 색상 클래스가 변경되었습니다. (예: text-zinc-600 → text-gray-600)
  * 디자인 시스템 및 웹 컴포넌트 전반에 걸쳐 동일한 클래스명 변경이 적용되었습니다.  
  * 불필요한 폰트 웨이트 CSS 변수들이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->