### PR TITLE
Feat(web): layout 페이지 분리 및 header, footer 추가

### DIFF
--- a/apps/web/app/(with-layout)/layout.tsx
+++ b/apps/web/app/(with-layout)/layout.tsx
@@ -1,0 +1,16 @@
+import Footer from 'components/footer/footer';
+import Header from 'components/header/header';
+
+export default function WithLayoutLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/app/(with-layout)/page.tsx
+++ b/apps/web/app/(with-layout)/page.tsx
@@ -1,7 +1,7 @@
 import { SvgJapaneseReview, SvgKoreanReview } from '@/icons';
-import HomeSection from './home/components/home';
-import HomeBanner from './home/components/home-banner';
-import HomeUpdateDate from './home/components/home-update-date';
+import HomeSection from '../home/components/home';
+import HomeBanner from '../home/components/home-banner';
+import HomeUpdateDate from '../home/components/home-update-date';
 
 export default function Main() {
   return (

--- a/apps/web/components/footer/footer.tsx
+++ b/apps/web/components/footer/footer.tsx
@@ -41,7 +41,7 @@ interface FooterProps {
 
 export default function Footer() {
   return (
-    <footer className="sticky bottom-0 flex w-full flex-col items-center justify-center overflow-hidden bg-pink-100">
+    <footer className="bottom-0 flex w-full flex-col items-center justify-center overflow-hidden bg-pink-100">
       <div className="flex w-full items-center gap-[12rem] px-[11.9rem] py-16">
         <FooterLeft title={FOOTER.title} desc={FOOTER.desc} />
         <FooterRight menu={FOOTER.menu} />

--- a/apps/web/components/header/header.tsx
+++ b/apps/web/components/header/header.tsx
@@ -60,7 +60,7 @@ export default function Header() {
   } = useHeaderAction();
 
   return (
-    <div className="sticky top-0 z-50 flex w-full flex-col bg-white">
+    <div className="z-55 sticky top-0 flex w-full flex-col bg-white">
       <TopUtil />
       <Gnb
         categories={categories}


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #89 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks
- 헤더 푸터 추가하기
- layout 폴더 분리

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] header, footer 레이아웃에 추가

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
- Badge에 z-index 넣어두었는데 Header랑 겹쳐서 z-index 수정했어요
- 추후에 Header랑 Footer가 들어가지 않는 페이지를 고려하기 위해서 layout을 (no-layout), (with-layout) 폴더로 구분했습니다 Header Footer가 필요한 페이지(현재 나와있는 모든 페이지)는 with-layout에 넣어두고 사용하는 걸 의도했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 헤더와 푸터가 포함된 레이아웃 컴포넌트가 추가되어 일관된 페이지 구조를 제공합니다.

* **스타일**
  * 푸터의 sticky 속성이 제거되어 스크롤 시 고정되지 않습니다.
  * 헤더의 z-index가 50에서 55로 조정되어 다른 요소와의 겹침 순서가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->