### PR TITLE
Feat(web) 쿠키를 활용한 로그인 상태로 좋아요 토글 및 헤더 로그인 상태 관리

### DIFF
--- a/apps/web/components/card/card-product.tsx
+++ b/apps/web/components/card/card-product.tsx
@@ -28,7 +28,7 @@ export default function CardProduct({
   imageUrl,
   handleCardClick,
 }: CardProductProps) {
-  const { isLiked, handleLikeClick } = useProductLike({
+  const { isLiked, handleLikeClick, userToken } = useProductLike({
     initialIsLiked,
   });
 
@@ -56,7 +56,7 @@ export default function CardProduct({
       <div className="flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-dashed border-pink-500">
         <p className="jp-body1 font-[700]">{brandName}</p>
         <IconButton
-          onClick={(e) => handleLikeClick(e, productId)}
+          onClick={(e) => handleLikeClick(e, productId, userToken)}
           size="md"
           icon={
             isLiked ? (

--- a/apps/web/components/card/hooks/use-product-like.ts
+++ b/apps/web/components/card/hooks/use-product-like.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PRODUCT_QUERIES } from 'app/(with-layout)/(home)/components/home-section-product';
 import { apiRequest } from 'app/api/apiRequest';
+import { getCookie } from 'utils/client-cookie';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
@@ -10,18 +11,7 @@ interface UseProductLikeProps {
 
 export function useProductLike({ initialIsLiked }: UseProductLikeProps) {
   const router = useRouter();
-  function getCookie(name: string): string | null {
-    if (typeof document === 'undefined') return null;
-
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) {
-      return parts.pop()?.split(';').shift() || null;
-    }
-    return null;
-  }
   const userToken = getCookie('AccessToken');
-  console.log(userToken);
   const [isLiked, setIsLiked] = useState(initialIsLiked);
   const queryClient = useQueryClient();
 
@@ -53,7 +43,7 @@ export function useProductLike({ initialIsLiked }: UseProductLikeProps) {
   const handleLikeClick = async (
     e: React.MouseEvent,
     productId: number,
-    userToken?: string | null
+    userToken?: string | null | undefined
   ) => {
     e.stopPropagation();
     if (!userToken) {

--- a/apps/web/components/card/hooks/use-product-like.ts
+++ b/apps/web/components/card/hooks/use-product-like.ts
@@ -2,12 +2,26 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { PRODUCT_QUERIES } from 'app/(with-layout)/(home)/components/home-section-product';
 import { apiRequest } from 'app/api/apiRequest';
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface UseProductLikeProps {
   initialIsLiked: boolean;
 }
 
 export function useProductLike({ initialIsLiked }: UseProductLikeProps) {
+  const router = useRouter();
+  function getCookie(name: string): string | null {
+    if (typeof document === 'undefined') return null;
+
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+      return parts.pop()?.split(';').shift() || null;
+    }
+    return null;
+  }
+  const userToken = getCookie('AccessToken');
+  console.log(userToken);
   const [isLiked, setIsLiked] = useState(initialIsLiked);
   const queryClient = useQueryClient();
 
@@ -36,13 +50,22 @@ export function useProductLike({ initialIsLiked }: UseProductLikeProps) {
     },
   });
 
-  const handleLikeClick = async (e: React.MouseEvent, productId: number) => {
+  const handleLikeClick = async (
+    e: React.MouseEvent,
+    productId: number,
+    userToken?: string | null
+  ) => {
     e.stopPropagation();
+    if (!userToken) {
+      router.push('/login');
+      return;
+    }
     likeMutation.mutate(productId);
   };
 
   return {
     isLiked,
     handleLikeClick,
+    userToken,
   };
 }

--- a/apps/web/components/header/header-content.tsx
+++ b/apps/web/components/header/header-content.tsx
@@ -2,6 +2,8 @@
 
 import type { CategoryOptionEng, CategoryNameEng } from 'types/category';
 import { CategoryMetadata, getOptionLabel } from 'utils/category';
+import { deleteCookie, getCookie } from 'utils/client-cookie';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
@@ -63,9 +65,27 @@ export function TopUtilItem({ icon, label, onClick }: TopUtilItemProps) {
     </button>
   );
 }
-
 export function TopUtil() {
   const router = useRouter();
+  const [userToken, setUserToken] = useState(getCookie('AccessToken'));
+  const [loginLabel, setLoginLabel] = useState('ログイン');
+
+  useEffect(() => {
+    if (userToken) {
+      setLoginLabel('ログアウト');
+    } else {
+      setLoginLabel('ログイン');
+    }
+  }, [userToken]);
+
+  const handleAuthClick = () => {
+    if (userToken) {
+      deleteCookie('AccessToken');
+      setUserToken(null);
+    } else {
+      router.push('/login');
+    }
+  };
 
   return (
     <div className="flex w-full items-center justify-end self-stretch px-[11.9rem] py-[2rem]">
@@ -81,13 +101,13 @@ export function TopUtil() {
       />
       <TopUtilItem
         icon={<SvgHistory className="text-gray-600" size={16} />}
-        label="最近見た商品"
+        label="最近見た商품"
         onClick={() => console.log('내역 클릭')}
       />
       <TopUtilItem
         icon={<SvgLogin className="text-gray-600" size={16} />}
-        label="ログイン"
-        onClick={() => router.push('/login')}
+        label={loginLabel}
+        onClick={handleAuthClick}
       />
     </div>
   );

--- a/apps/web/utils/client-cookie.ts
+++ b/apps/web/utils/client-cookie.ts
@@ -8,3 +8,9 @@ export function getCookie(name: string): string | null {
   }
   return null;
 }
+
+export function deleteCookie(name: string): void {
+  if (typeof document === 'undefined') return;
+
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`;
+}

--- a/apps/web/utils/client-cookie.ts
+++ b/apps/web/utils/client-cookie.ts
@@ -1,0 +1,10 @@
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) {
+    return parts.pop()?.split(';').shift() || null;
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #145 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks
- 로그인 안 했을 때 좋아요 누르면 로그인 페이지로 이동
- 로그인 유무에 따라 헤더에서 로그인 상태 확인 가능하도록 수정

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] 로그인 상태 확인
- [X] 로그인 상태에 따른 분기 처리(좋아요 토글)
- [X] 로그인 상태에 따른 분기 처리(헤더)

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 로그인하지 않은 상태에서 상품 좋아요를 시도하면 로그인 페이지로 리디렉션됩니다.
  * 로그인 상태에 따라 상단 유틸리티의 버튼이 "로그인"/"로그아웃"으로 동적으로 변경됩니다.
  * 클라이언트에서 쿠키를 읽고 삭제하는 기능이 추가되었습니다.

* **버그 수정**
  * "최근 본 상품"의 라벨이 "최근 본 상픔"으로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->