### PR TITLE
Bug(web): 검증된 유튜브 영상들로 map 대상 변경

### DIFF
--- a/apps/web/app/(with-layout)/product-detail/[productId]/components/youtube-carousel.tsx
+++ b/apps/web/app/(with-layout)/product-detail/[productId]/components/youtube-carousel.tsx
@@ -74,7 +74,7 @@ export default function YoutubeCarousel({
               modules={[Navigation]}
               className="youtube-swiper"
             >
-              {youtubeListData?.youtubeUrls?.map((video) => (
+              {validatedYoutubeListData?.map((video) => (
                 <SwiperSlide key={video}>
                   <iframe
                     width="552"


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #170

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] 검증된 유튜브 영상들로 map 대상 변경

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->

<img width="413" height="492" alt="image" src="https://github.com/user-attachments/assets/4dbd583a-96ad-4fee-a891-b7456e3aa881" />
이 상태였던 것들
<img width="1351" height="443" alt="image" src="https://github.com/user-attachments/assets/f1fe1583-5112-43fd-ae5e-bf7dec1919d1" />
이렇게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 유효성 검증을 통과한 YouTube URL만 비디오 슬라이드에 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->