### PR TITLE
Bug(web): 헤더 최상단 버튼 속성 수정 및 z-index 설정

### DIFF
--- a/apps/web/components/header/header-content.tsx
+++ b/apps/web/components/header/header-content.tsx
@@ -23,6 +23,7 @@ interface TopUtilItemProps {
   icon: React.ReactNode;
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 }
 
 interface CategoryBarProps {
@@ -54,11 +55,17 @@ interface SearchBarProps {
   handleSearchIconClick: () => void;
 }
 
-export function TopUtilItem({ icon, label, onClick }: TopUtilItemProps) {
+export function TopUtilItem({
+  icon,
+  label,
+  onClick,
+  disabled = false,
+}: TopUtilItemProps) {
   return (
     <button
       onClick={onClick}
-      className="flex h-[3.2rem] cursor-pointer items-center justify-center gap-[0.8rem] whitespace-nowrap px-[1.6rem] py-[1rem]"
+      className="flex h-[3.2rem] cursor-pointer items-center justify-center gap-[0.8rem] whitespace-nowrap px-[1.6rem] py-[1rem] disabled:cursor-not-allowed"
+      disabled={disabled}
     >
       {icon}
       <p className="jp-body2 text-gray-600">{label}</p>
@@ -98,16 +105,19 @@ export function TopUtil({ visible }: { visible: boolean }) {
         icon={<SvgMy className="text-gray-600" size={16} />}
         label="マイページ"
         onClick={() => console.log('마이페이지 클릭')}
+        disabled
       />
       <TopUtilItem
         icon={<SvgLikeFill className="text-gray-600" size={16} />}
         label="お気に入り"
         onClick={() => console.log('좋아요 클릭')}
+        disabled
       />
       <TopUtilItem
         icon={<SvgHistory className="text-gray-600" size={16} />}
         label="最近見た商품"
         onClick={() => console.log('내역 클릭')}
+        disabled
       />
       <TopUtilItem
         icon={<SvgLogin className="text-gray-600" size={16} />}

--- a/apps/web/components/header/header.tsx
+++ b/apps/web/components/header/header.tsx
@@ -31,7 +31,7 @@ const header = React.memo(function Header() {
       />
       <div
         className={cn(
-          'z-55 sticky top-0 mx-auto flex w-full min-w-[1366px] flex-col bg-white',
+          'sticky top-0 z-30 mx-auto flex w-full min-w-[1366px] flex-col bg-white',
           (isSearching || selectedCategory) &&
             'border-b border-dashed border-pink-500',
           !selectedCategory &&

--- a/packages/design-system/src/components/badge/Badge.tsx
+++ b/packages/design-system/src/components/badge/Badge.tsx
@@ -9,7 +9,7 @@ interface BadgeProps {
 const OTHER_RANK_STYLE = `border-b-[0.1rem] border-r-[0.1rem] border-pink-500 bg-pink-100 text-pink-500`;
 
 const badgeVariants = cva(
-  `en-title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 z-50`,
+  `en-title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 absolute`,
   {
     variants: {
       variant: {


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #173 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] header, card 컴포넌트 z-index 수정
- [x] 클릭할 수 없는 버튼 disabled 처리

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 상단 유틸리티 버튼(마이페이지, 즐겨찾기, 최근 본 상품)에 비활성화(disabled) 상태가 적용되어 클릭할 수 없도록 변경되었습니다.

* **스타일**
  * 헤더와 뱃지 컴포넌트의 z-index(쌓임 순서) 및 스타일이 일부 조정되어 레이아웃 및 시각적 계층이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->