### PR TITLE
Refactor(web): 리뷰 모달에서 상품 정보 클릭 시 해당 상품으로 이동

### DIFF
--- a/apps/web/app/review-modal/[reviewId]/image/page.tsx
+++ b/apps/web/app/review-modal/[reviewId]/image/page.tsx
@@ -90,6 +90,7 @@ export default function Page() {
 
     return {
       reviewId: detail.reviewId,
+      productId: detail.productId,
       writtenTime: formatDateToJapanese(detail.writtenTime),
       receiptUploaded: detail.receiptUploaded,
       positiveComment: detail.positiveComment,

--- a/apps/web/app/review-modal/[reviewId]/video/page.tsx
+++ b/apps/web/app/review-modal/[reviewId]/video/page.tsx
@@ -90,6 +90,7 @@ export default function Page() {
 
     return {
       reviewId: detail.reviewId,
+      productId: detail.productId,
       writtenTime: formatDateToJapanese(detail.uploadAt),
       receiptUploaded: !!detail.receiptImageUrl,
       positiveComment: detail.positiveContent,

--- a/apps/web/app/review-modal/components/review-info.tsx
+++ b/apps/web/app/review-modal/components/review-info.tsx
@@ -13,6 +13,7 @@ import Comment from './comment';
 type ReviewInfoProps = Pick<
   ReviewDetail,
   | 'reviewId'
+  | 'productId'
   | 'rating'
   | 'option'
   | 'positiveComment'
@@ -26,7 +27,7 @@ type ReviewInfoProps = Pick<
 };
 
 export default function ReviewInfo({
-  reviewId: productId,
+  productId,
   rating,
   option: productOption,
   positiveComment,

--- a/apps/web/app/review-modal/components/review-modal-layout.tsx
+++ b/apps/web/app/review-modal/components/review-modal-layout.tsx
@@ -12,6 +12,7 @@ export interface User {
 }
 export interface ReviewModallayoutProps {
   id: number;
+  productId: number;
   mediaList: Media[];
   user: User;
   likeCount: number;
@@ -30,6 +31,7 @@ export interface ReviewModallayoutProps {
 
 export default function ReviewModallayout({
   id,
+  productId,
   mediaList,
   user,
   likeCount,
@@ -62,6 +64,7 @@ export default function ReviewModallayout({
         <div className="relative flex w-[38.4rem] flex-col">
           <ReviewInfo
             reviewId={id}
+            productId={productId}
             brandName={brandName}
             productName={productName}
             option={productOption}

--- a/apps/web/app/review-modal/components/review-modal-swiper.tsx
+++ b/apps/web/app/review-modal/components/review-modal-swiper.tsx
@@ -42,6 +42,7 @@ export default function ReviewModalSwiper({
         >
           <ReviewModalLayout
             id={review.reviewId}
+            productId={review.productId}
             mediaList={review.mediaList}
             user={{
               name: review.authorName,

--- a/apps/web/app/review-modal/types/index.ts
+++ b/apps/web/app/review-modal/types/index.ts
@@ -1,5 +1,6 @@
 export interface ReviewDetailBase {
   reviewId: number;
+  productId: number;
   writtenTime: string;
   receiptUploaded: boolean;
   positiveComment: string;


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #126 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->
- [x] 리뷰 모달에서 상품 이미지/브랜드명/상품명 클릭할 경우 해당 productId 상세 페이지로 이동 

## To Reviewer


## Screenshot

https://github.com/user-attachments/assets/6c6e232a-988a-433d-b2a6-9c8f24db58c9





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 리뷰 상세 정보에 상품 ID(productId)가 추가되어, 리뷰에서 해당 상품 상세 페이지로 이동할 수 있습니다.

* **버그 수정**
  * 리뷰 모달 내 정보 전달 구조가 개선되어, 상품 ID가 정확하게 연결됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->