### PR TITLE
Feat(web):  video 플레이어 영상 원본 비율로 플레이 

### DIFF
--- a/apps/web/app/review-modal/components/video-player.tsx
+++ b/apps/web/app/review-modal/components/video-player.tsx
@@ -54,7 +54,7 @@ export default function VideoLayout({ url }: VideoLayoutProps) {
         controls={false}
         loop
         playsInline
-        className="h-full w-full cursor-pointer object-cover"
+        className="h-full w-full cursor-pointer object-contain"
         onClick={handleVideoClick}
       />
       <div


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #204 

기존에는 레이아웃 비율에 맞춰 1:1 비율로 영상이 맞춰서 보여졌는데, 영상 원본 비율로 유지되도록 수정했습니당

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] video 플레이어 영상 원본 비율로 보여지도록

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot


https://github.com/user-attachments/assets/259c486a-2172-4a86-b46b-ae1dc7b9d9c6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 비디오 플레이어에서 영상이 컨테이너 내에 전체가 보이도록 스타일이 변경되었습니다. 이제 영상이 잘리지 않고 전체 프레임이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->