### PR TITLE
Feat(*): develop 브랜치 자동 동기화 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
+      - name: Checkout current branch
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.AUTO_ACTIONS }}
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.ref_name }} 
 
       - name: Add remote-url
         run: |
@@ -26,7 +26,7 @@ jobs:
 
       - name: Push changes to forked-repo
         run: |
-          git push -f forked-repo main
+          git push -f forked-repo ${{ github.ref_name }}
 
       - name: Clean up
         run: |


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #276 

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] develop 자동 배포 워크플로우 수정
- [x] `ref: main → ref: ${{ github.ref_name }}`로 변경하여, 현재 푸시된 브랜치를 기준으로 코드 가져오도록 개선

## To Reviewer

- GitHub Actions 워크플로우에서 main 브랜치 외에 develop 브랜치도 자동 동기화되도록 수정했습니다. 
- ref: ${{ github.ref_name }} 구문을 사용하여 푸시된 브랜치(main 또는 develop)에 따라 해당 브랜치 기준으로 동기화 되도록 수정했습니다. 
- `on.push.branches: [main, develop]` → main 또는 develop에 푸시될 때만 워크플로가 실행됨
- `ref: ${{ github.ref_name }}` → 푸시된 브랜치에 맞춰 동기화 수행

## 참고자료
- [Github Actions - github context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우가 특정 브랜치가 아닌 현재 브랜치에 맞게 동작하도록 개선되었습니다.  
  * 워크플로우 실행 시 현재 브랜치가 자동으로 동기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->