### PR TITLE
Feat(*): Jira 연동

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Template
 about: "\U0001F41E 버그가 발생한 경우 사용해주세요"
-title: ''
+title: 'LCO-00'
 labels: ''
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-template.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Template
 about: '✨ 새로운 기능을 추가하는 경우 사용해주세요'
-title: ''
+title: 'LCO-00 '
 labels: ''
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -1,0 +1,47 @@
+name: 'Issue'
+description: '새로 생성된 이슈는 Jira와 연동돼요'
+title: 'Issue 제목을 작성해주세요'
+body:
+  - type: input
+    id: parentKey
+    attributes:
+      label: 'Ticket Number'
+      description: '상위 작업의 Ticket Number를 기입해주세요'
+      placeholder: 'CRA-00'
+    validations:
+      required: true
+
+  - type: input
+    id: description
+    attributes:
+      label: 'Description'
+      description: '이슈에 대해 간략히 설명해주세요'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issueLabel
+    attributes:
+      label: 'Label'
+      description: '이슈의 라벨을 선택해주세요'
+      multiple: true
+      options:
+        - Feature
+        - Fix
+        - DOCS
+        - Refactor
+        - Setting
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: 'Tasks'
+      description: '이슈에 대한 필요한 작업 목록을 작성해주세요'
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor-template.md
+++ b/.github/ISSUE_TEMPLATE/refactor-template.md
@@ -1,7 +1,7 @@
 ---
 name: Refactor Template
 about: "\U0001F6E0️ 변경사항이 생긴 경우 사용해주세요"
-title: ''
+title: 'LCO-00'
 labels: ''
 assignees: ''
 ---

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,0 +1,31 @@
+name: Close Jira issue
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  close-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Extract Jira issue key
+        id: extract-key
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const m = context.payload.issue.title.match(/[A-Z]+-\d+/);
+            return m ? m[0] : '';
+
+      - name: Close Jira issue
+        if: steps.extract-key.outputs.result != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.extract-key.outputs.result }}
+           transition: 완료

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -28,4 +28,4 @@ jobs:
         uses: atlassian/gajira-transition@v3
         with:
           issue: ${{ steps.extract-key.outputs.result }}
-           transition: 완료
+          transition: 완료

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,88 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout dev code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/issue-form.yml
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+                  input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: LCO
+          issuetype: 하위 작업
+          summary: ${{ github.event.issue.title }}
+          description: ${{ steps.md2jira.outputs.output-text }}
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Transition to In Progress
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.create.outputs.issue }}
+          transition: 진행 중
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.issue-parser.outputs.issueparser_parentKey }}/${{ steps.create.outputs.issue }} was created"
+
+      - name: Create branch with Ticket number
+        run: |
+          LABELS="${{ steps.issue-parser.outputs.issueparser_issueLabel }}"
+          BRANCH_PREFIX="${LABELS%%,*}"
+          ISSUE_NUMBER="${{ steps.create.outputs.issue }}"
+          BRANCH_NAME="${BRANCH_PREFIX}/${ISSUE_NUMBER}"
+          git checkout -b "${BRANCH_NAME}"
+          git push origin "${BRANCH_NAME}"
+
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: update-issue
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+
+      - name: Add comment with Jira issue link
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: create-comment
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Jira Issue Created: [${{ steps.create.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }})

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -32,7 +32,7 @@ jobs:
         uses: peter-evans/jira2md@v1
         id: md2jira
         with:
-                  input-text: |
+          input-text: |
             ### Github Issue Link
             - ${{ github.event.issue.html_url }}
             ${{ github.event.issue.body }}


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #282 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->
Jira와 Github를 연동했어요

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] Jira - Github 이슈 연동

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
저도 잘 몰라서 @huncozyboy 가 서버 쪽 세팅한 거 보고 훔쳐왔습니다 🫠... 땡스투 지훈리!!! (https://github.com/LO-CO-CO/LOCOCO-SERVER/pull/175) 설명도 훔쳐왔어요

1. LCO-1 테스크 코드 작성 (예시) 이라는 티켓을 지라에서 생성
2. 깃허브에서 이슈를 생성할때 상위 작업의 티켓을 LCO-1로 입력
3. 작업 제목에는 JWT 테스트 코드 작성 이라고 입력하여 생성
4. 이슈 제목 자동으로 [LCO-2] JWT 테스트 코드 작성 으로 생성됨 (상위 티켓은 LCO-1로 설정됨)

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


[LCO-2]: https://lococobeauty.atlassian.net/browse/LCO-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 이슈 템플릿 및 이슈 폼이 추가되어, 이슈 생성 시 Jira와 연동되는 구조화된 입력이 가능합니다.
  * GitHub 이슈 생성 시 자동으로 Jira 하위 이슈가 생성되고, 이슈가 닫히면 Jira 이슈가 자동으로 완료 처리됩니다.
* **Chores**
  * 빈 이슈 생성을 비활성화하여, 반드시 템플릿을 통해 이슈를 생성하도록 변경되었습니다.
  * 버그, 기능, 리팩터 이슈 템플릿의 기본 제목이 "LCO-00"으로 지정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->