### PR TITLE
Feat(design-system): StandardButton 공통 컴포넌트 디자인 변경에 따른 수정

### DIFF
--- a/packages/design-system/src/components/button/Button.stories.tsx
+++ b/packages/design-system/src/components/button/Button.stories.tsx
@@ -13,13 +13,14 @@ const meta: Meta<typeof Button> = {
       control: 'radio',
       options: ['primary', 'secondary'],
     },
-    rounded: { control: 'boolean' },
     size: { control: 'radio', options: ['lg', 'md', 'sm'] },
+    disabled: { control: 'boolean' },
   },
 };
 export default meta;
 type Story = StoryObj<typeof Button>;
 
+// FILLED VARIANTS
 export const FilledPrimary: Story = {
   args: {
     children: 'Label',
@@ -29,13 +30,21 @@ export const FilledPrimary: Story = {
   },
 };
 
-export const FilledPrimaryRounded: Story = {
+export const FilledPrimaryMedium: Story = {
   args: {
     children: 'Label',
     variant: 'filled',
     color: 'primary',
-    rounded: true,
     size: 'md',
+  },
+};
+
+export const FilledPrimarySmall: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'sm',
   },
 };
 
@@ -59,6 +68,47 @@ export const FilledPrimaryWithRightIcon: Story = {
   },
 };
 
+export const FilledPrimaryMediumWithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'md',
+    iconLeft: <SvgErrorFill />,
+  },
+};
+
+export const FilledPrimaryMediumWithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'md',
+    iconRight: <SvgErrorFill />,
+  },
+};
+
+export const FilledPrimarySmallWithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'sm',
+    iconLeft: <SvgErrorFill />,
+  },
+};
+
+export const FilledPrimarySmallWithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'sm',
+    iconRight: <SvgErrorFill />,
+  },
+};
+
+// OUTLINE VARIANTS
 export const OutlineDefault: Story = {
   args: {
     children: 'Label',
@@ -68,6 +118,45 @@ export const OutlineDefault: Story = {
   },
 };
 
+export const OutlineDefaultMedium: Story = {
+  args: {
+    children: 'Label',
+    variant: 'outline',
+    color: 'primary',
+    size: 'md',
+  },
+};
+
+export const OutlineDefaultSmall: Story = {
+  args: {
+    children: 'Label',
+    variant: 'outline',
+    color: 'primary',
+    size: 'sm',
+  },
+};
+
+export const OutlineDefaultWithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'outline',
+    color: 'primary',
+    size: 'lg',
+    iconLeft: <SvgErrorFill />,
+  },
+};
+
+export const OutlineDefaultWithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'outline',
+    color: 'primary',
+    size: 'lg',
+    iconRight: <SvgErrorFill />,
+  },
+};
+
+// TEXT VARIANTS
 export const TextPrimary: Story = {
   args: {
     children: 'Label',
@@ -77,6 +166,45 @@ export const TextPrimary: Story = {
   },
 };
 
+export const TextPrimaryMedium: Story = {
+  args: {
+    children: 'Label',
+    variant: 'text',
+    color: 'primary',
+    size: 'md',
+  },
+};
+
+export const TextPrimarySmall: Story = {
+  args: {
+    children: 'Label',
+    variant: 'text',
+    color: 'primary',
+    size: 'sm',
+  },
+};
+
+export const TextPrimaryWithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'text',
+    color: 'primary',
+    size: 'lg',
+    iconLeft: <SvgErrorFill />,
+  },
+};
+
+export const TextPrimaryWithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'text',
+    color: 'primary',
+    size: 'lg',
+    iconRight: <SvgErrorFill />,
+  },
+};
+
+// SECONDARY VARIANTS
 export const FilledSecondary: Story = {
   args: {
     children: 'Label',
@@ -86,7 +214,45 @@ export const FilledSecondary: Story = {
   },
 };
 
-export const LargeTextSecondary: Story = {
+export const FilledSecondaryMedium: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'secondary',
+    size: 'md',
+  },
+};
+
+export const FilledSecondarySmall: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'secondary',
+    size: 'sm',
+  },
+};
+
+export const FilledSecondaryWithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'secondary',
+    size: 'lg',
+    iconLeft: <SvgErrorFill />,
+  },
+};
+
+export const FilledSecondaryWithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'secondary',
+    size: 'lg',
+    iconRight: <SvgErrorFill />,
+  },
+};
+
+export const TextSecondary: Story = {
   args: {
     children: 'Label',
     variant: 'text',
@@ -95,20 +261,41 @@ export const LargeTextSecondary: Story = {
   },
 };
 
-export const MediumFilledPrimary: Story = {
+export const TextSecondaryMedium: Story = {
   args: {
     children: 'Label',
-    variant: 'filled',
-    color: 'primary',
+    variant: 'text',
+    color: 'secondary',
     size: 'md',
   },
 };
 
-export const SmallTextPrimary: Story = {
+export const TextSecondarySmall: Story = {
+  args: {
+    children: 'Label',
+    variant: 'text',
+    color: 'secondary',
+    size: 'sm',
+  },
+};
+
+// DISABLED VARIANTS
+export const FilledPrimaryDisabled: Story = {
+  args: {
+    children: 'Label',
+    variant: 'filled',
+    color: 'primary',
+    size: 'lg',
+    disabled: true,
+  },
+};
+
+export const TextPrimaryDisabled: Story = {
   args: {
     children: 'Label',
     variant: 'text',
     color: 'primary',
-    size: 'sm',
+    size: 'lg',
+    disabled: true,
   },
 };

--- a/packages/design-system/src/components/button/Button.tsx
+++ b/packages/design-system/src/components/button/Button.tsx
@@ -1,6 +1,8 @@
-import { Slot } from '@radix-ui/react-slot';
-import { cva, VariantProps } from 'class-variance-authority';
 import { ButtonHTMLAttributes, ReactNode, forwardRef } from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { VariantProps, cva } from 'class-variance-authority';
+
 import { cn } from '../../lib/utils';
 
 interface ButtonProps
@@ -8,14 +10,13 @@ interface ButtonProps
     VariantProps<typeof buttonVariants> {
   iconLeft?: ReactNode;
   iconRight?: ReactNode;
-  rounded?: boolean;
   color: 'primary' | 'secondary';
   variant: 'filled' | 'outline' | 'text';
   size: 'lg' | 'md' | 'sm';
   asChild?: boolean;
 }
 
-const baseButtonStyle = 'px-[3.2rem] py-[1rem] gap-[0.8rem]';
+const baseButtonStyle = 'rounded-[3.2rem] py-[1rem] gap-[0.8rem]';
 
 const buttonVariants = cva(
   'flex items-center transition-colors duration-300 justify-center font-bold disabled:bg-gray-200 disabled:text-gray-500 disabled:cursor-not-allowed cursor-pointer grow',
@@ -23,21 +24,17 @@ const buttonVariants = cva(
     variants: {
       variant: {
         filled: '',
-        outline: 'bg-transparent border-b',
+        outline: 'bg-white border border-pink-500 text-pink-500',
         text: 'bg-transparent',
       },
       color: {
         primary: '',
         secondary: '',
       },
-      rounded: {
-        true: 'rounded-[0.8rem]',
-        false: '',
-      },
       size: {
-        lg: `h-[6rem] ${baseButtonStyle}`,
-        md: `h-[5.2rem] ${baseButtonStyle}`,
-        sm: `h-[3.2rem] px-[1.6rem] py-[1rem] gap-[0.8rem]`,
+        lg: `h-[6.4rem] px-[3.2rem] ${baseButtonStyle}`,
+        md: `h-[5.6rem] px-[3.2rem] ${baseButtonStyle}`,
+        sm: `h-[4.8rem] px-[2.4rem] ${baseButtonStyle}`,
       },
     },
     compoundVariants: [
@@ -54,8 +51,7 @@ const buttonVariants = cva(
       {
         variant: 'outline',
         color: 'primary',
-        class:
-          'border-pink-500 text-pink-500 hover:bg-pink-100 hover:text-pink-500 hover:border-pink-500',
+        class: 'hover:bg-pink-100',
       },
       {
         variant: 'text',
@@ -72,7 +68,6 @@ const buttonVariants = cva(
       variant: 'filled',
       color: 'primary',
       size: 'md',
-      rounded: false,
     },
   }
 );
@@ -87,7 +82,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconRight,
       children,
       className,
-      rounded = false,
       asChild = false,
       disabled,
       ...props
@@ -109,10 +103,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <Comp
         disabled={disabled}
         ref={ref}
-        className={cn(
-          buttonVariants({ variant, color, size, rounded }),
-          className
-        )}
+        className={cn(buttonVariants({ variant, color, size }), className)}
         {...props}
       >
         {buttonContent}


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary
<img width="1490" height="579" alt="스크린샷 2025-08-28 오후 7 37 28" src="https://github.com/user-attachments/assets/d71e0017-12dc-4689-b6f1-a543b1c5ec84" />
ummary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #301 

- 변경된 기본 버튼 디자인에 맞추어 수정 진행했습니다!

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] Button.tsx 컴포넌트 수정 
- [x] Button.stories.tsx 경우의 수 더욱 구체적으로 작성
    - Filled, Outline, Text variant별 스토리 구성
    - Primary/Secondary 색상별 스토리 구성
    - Large/Medium/Small 크기별 스토리 구성
    - Left/Right 아이콘 위치별 스토리 구성
    - Disabled 상태 스토리 추가
    - Controls에서 variant, color, size, disabled 변경 가능

## To Reviewer

- 기존에는 버튼 rounded가 있는 경우와 없는 경우가 있었는데, 
   변경된 디자인에서는 모든 버튼이 rounded로 통일되어서 rounded props를 제거하였습니다.

## Screenshot
https://github.com/user-attachments/assets/24863912-94c6-49e2-87b7-a3989cdfdf7d

