### PR TITLE
Feat(Web): 번역플로우 자동화 구글시트

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 next-env.d.ts
 
 certificates
+
+/translate/credentials.json

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "start": "next start",
     "prettier": "prettier --write .",
     "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "translate:download": "node translate/download.js",
+    "translate:upload": "node translate/upload.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,8 +10,8 @@
     "prettier": "prettier --write .",
     "lint": "next lint --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "translate:download": "node --env-file .env translate/download.js",
-    "translate:upload": "node --env-file .env translate/upload.js"
+    "translate:download": "node --env-file .env.local translate/download.js",
+    "translate:upload": "node --env-file .env.local translate/upload.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier --write .",
     "lint": "next lint --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "translate:download": "node translate/download.js",
+    "translate:download": "node --env-file .env translate/download.js",
     "translate:upload": "node translate/upload.js"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint --max-warnings 0",
     "check-types": "tsc --noEmit",
     "translate:download": "node --env-file .env translate/download.js",
-    "translate:upload": "node translate/upload.js"
+    "translate:upload": "node --env-file .env translate/upload.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,8 @@
     "dayjs": "^1.11.13",
     "design-system:build": "link:@lococo/design-system:build",
     "es-toolkit": "^1.39.6",
+    "google-auth-library": "^10.3.0",
+    "google-spreadsheet": "^5.0.2",
     "install": "^0.13.0",
     "next": "^15.3.5",
     "next-intl": "^4.3.5",

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -1,0 +1,113 @@
+// place in translate/download.js
+//const mkdirp = require('mkdirp');
+const {
+  loadSpreadsheet,
+  localesPath,
+  ns,
+  lngs,
+  sheetId,
+  columnKeyToHeader,
+  NOT_AVAILABLE_CELL,
+} = await import('./index.js');
+
+// 언어 코드 → 숫자 매핑
+// _rawData 인덱스 매핑 ex) _rowData=[key값, 한글, 영어, 스페인어]
+const langToNumber = {
+  ko: 1,
+  en: 2,
+  es: 3,
+};
+
+function getNumberByLang(lang) {
+  return langToNumber[lang] ?? 0; // 매핑되지 않으면 0 리턴
+}
+
+// 평면화된 키를 중첩 객체로 변환하는 함수
+function unflattenObject(flatObj) {
+  const result = {};
+
+  for (const [key, value] of Object.entries(flatObj)) {
+    const keys = key.split('.');
+    let current = result;
+
+    // 마지막 키를 제외한 모든 키에 대해 중첩 객체 생성
+    for (let i = 0; i < keys.length - 1; i++) {
+      const currentKey = keys[i];
+      if (!current[currentKey]) {
+        current[currentKey] = {};
+      }
+      current = current[currentKey];
+    }
+
+    // 마지막 키에 값 할당
+    const lastKey = keys[keys.length - 1];
+    current[lastKey] = value;
+  }
+
+  return result;
+}
+
+async function fetchTranslationsFromSheetToJson(doc) {
+  const sheet = doc.sheetsById[sheetId];
+  if (!sheet) {
+    return {};
+  }
+
+  const lngsMap = {};
+  const rows = await sheet.getRows();
+  // 각 언어별로 평면화된 객체를 먼저 생성
+  const flatLngsMap = {};
+
+  rows.forEach((row) => {
+    const key = row._rawData[0];
+    lngs.forEach((lng) => {
+      const translation = row._rawData[getNumberByLang(lng)];
+      // 번역과 관련없는 값은 빈 문자열로 처리 NOT_AVAILABLE_CELL("_N/A")
+      if (translation === NOT_AVAILABLE_CELL) {
+        return;
+      }
+
+      if (!flatLngsMap[lng]) {
+        flatLngsMap[lng] = {};
+      }
+
+      flatLngsMap[lng][key] = translation || ''; // prevent to remove undefined value like ({"key": undefined})
+    });
+  });
+
+  // 각 언어별로 평면화된 객체를 중첩 객체로 변환
+  for (const [lng, flatObj] of Object.entries(flatLngsMap)) {
+    const nestedObj = unflattenObject(flatObj);
+
+    lngsMap[lng] = nestedObj;
+  }
+
+  return lngsMap;
+}
+
+async function updateJsonFromSheet() {
+  const fs = await import('fs');
+
+  const doc = await loadSpreadsheet();
+  const lngsMap = await fetchTranslationsFromSheetToJson(doc);
+  fs.readdir(localesPath, (error, lngs) => {
+    if (error) {
+      console.log('readdir error', error);
+      throw error;
+    }
+
+    lngs.forEach((lng) => {
+      const localeJsonFilePath = `${localesPath}/${lng}`;
+
+      lng = lng.replace('.json', '');
+      const jsonString = JSON.stringify(lngsMap[lng], null, 2);
+      fs.writeFile(localeJsonFilePath, jsonString, 'utf8', (err) => {
+        if (err) {
+          throw err;
+        }
+      });
+    });
+  });
+}
+
+updateJsonFromSheet();

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -148,6 +148,7 @@ async function updateJsonFromSheet() {
         if (err) {
           throw err;
         }
+        console.log(`${lng} 파일 다운로드 완료 ✅`);
       });
     });
   });

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -59,6 +59,11 @@ function unflattenObject(flatObj) {
     // 마지막 키를 제외한 모든 키에 대해 중첩 객체 생성
     for (let i = 0; i < keys.length - 1; i++) {
       const currentKey = keys[i];
+
+      if (current[currentKey] && typeof current[currentKey] !== 'object') {
+        current[currentKey] = { _value: current[currentKey] };
+      }
+
       if (!current[currentKey]) {
         current[currentKey] = {};
       }
@@ -67,6 +72,10 @@ function unflattenObject(flatObj) {
 
     // 마지막 키에 값 할당
     const lastKey = keys[keys.length - 1];
+
+    if (current[lastKey] && typeof current[lastKey] !== 'object') {
+      current[lastKey] = { _value: current[lastKey] };
+    }
     current[lastKey] = value;
   }
 

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -1,3 +1,8 @@
+/**
+ * @fileoverview Google Sheets에서 번역 데이터를 다운로드하고 JSON 파일로 변환하는 모듈
+ * @author LOKOKO Team JaeHoon
+ */
+
 // place in translate/download.js
 //const mkdirp = require('mkdirp');
 const {
@@ -10,19 +15,40 @@ const {
   NOT_AVAILABLE_CELL,
 } = await import('./index.js');
 
-// 언어 코드 → 숫자 매핑
-// _rawData 인덱스 매핑 ex) _rowData=[key값, 한글, 영어, 스페인어]
+/**
+ * 언어 코드를 Google Sheets의 _rawData 인덱스로 매핑하는 객체
+ * @description _rawData 배열 구조: [key값, 한글, 영어, 스페인어]
+ * @type {Object.<string, number>}
+ */
 const langToNumber = {
   ko: 1,
   en: 2,
   es: 3,
 };
 
+/**
+ * 언어 코드에 해당하는 _rawData 인덱스를 반환
+ * @param {string} lang - 언어 코드 (ko, en, es)
+ * @returns {number} 해당 언어의 _rawData 인덱스
+ * @throws {Error} 지원하지 않는 언어 코드인 경우 에러 발생
+ * @example
+ * getNumberByLang('ko') // 1
+ * getNumberByLang('en') // 2
+ * getNumberByLang('unknown') // Error: Unsupported language code: unknown
+ */
 function getNumberByLang(lang) {
-  return langToNumber[lang] ?? 0; // 매핑되지 않으면 0 리턴
+  if (!(lang in langToNumber)) {
+    throw new Error(`Unsupported language code: ${lang}`);
+  }
+  return langToNumber[lang];
 }
 
-// 평면화된 키를 중첩 객체로 변환하는 함수
+/**
+ * 평면화된 키를 중첩 객체로 변환하는 함수
+ * @description 점(.)으로 구분된 키를 중첩 객체 구조로 변환
+ * @param {Object.<string, string>} flatObj - 평면화된 키-값 객체
+ * @returns {Object} 중첩 구조로 변환된 객체
+ */
 function unflattenObject(flatObj) {
   const result = {};
 
@@ -85,6 +111,15 @@ async function fetchTranslationsFromSheetToJson(doc) {
   return lngsMap;
 }
 
+/**
+ * Google Sheets에서 번역 데이터를 가져와서 로컬 JSON 파일로 업데이트
+ * @description Google Sheets의 번역 데이터를 다운로드하여 각 언어별 JSON 파일로 저장
+ * @returns {Promise<void>}
+ * @throws {Error} 파일 읽기/쓰기 오류 시 발생
+ * @example
+ * await updateJsonFromSheet();
+ * // messages/ko.json, messages/en.json, messages/es.json 파일이 업데이트됨
+ */
 async function updateJsonFromSheet() {
   const fs = await import('fs');
 

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -146,6 +146,7 @@ async function updateJsonFromSheet() {
       const jsonString = JSON.stringify(lngsMap[lng], null, 2);
       fs.writeFile(localeJsonFilePath, jsonString, 'utf8', (err) => {
         if (err) {
+          console.log(`${lng} 파일 다운로드 실패 ❌`);
           throw err;
         }
         console.log(`${lng} 파일 다운로드 완료 ✅`);

--- a/apps/web/translate/download.js
+++ b/apps/web/translate/download.js
@@ -20,11 +20,10 @@ const {
  * @description _rawData 배열 구조: [key값, 한글, 영어, 스페인어]
  * @type {Object.<string, number>}
  */
-const langToNumber = {
-  ko: 1,
-  en: 2,
-  es: 3,
-};
+const langToNumber = lngs.reduce((acc, lng, index) => {
+  acc[lng] = index + 1; // _rawData[0]은 key이므로 1부터 시작
+  return acc;
+}, {});
 
 /**
  * 언어 코드에 해당하는 _rawData 인덱스를 반환

--- a/apps/web/translate/index.js
+++ b/apps/web/translate/index.js
@@ -1,0 +1,55 @@
+import { JWT } from 'google-auth-library';
+import { GoogleSpreadsheet } from 'google-spreadsheet';
+import credentials from './credentials.json' assert { type: 'json' };
+
+const ns = 'ko';
+const lngs = ['ko', 'en', 'es'];
+const localesPath = 'messages';
+const sheetId = 0; // your sheet id
+const NOT_AVAILABLE_CELL = '_N/A';
+const columnKeyToHeader = {
+  key: '키',
+  'ko-KR': '한글',
+  'en-US': '영어',
+  'es-AR': '스페인어',
+};
+
+// Initialize auth - see https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication
+const email = credentials.client_email;
+const key = credentials.private_key.replace(/\\n/g, '\n');
+
+const serviceAccountAuth = new JWT({
+  email,
+  key,
+  scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+});
+/**
+ * getting started from https://theoephraim.github.io/node-google-spreadsheet
+ */
+async function loadSpreadsheet() {
+  // spreadsheet key is the long id in the sheets URL
+  const doc = new GoogleSpreadsheet(
+    '1ZTHUZLuSDE9z-398uQDBAZ4ERhcmSHJ22uWJNcJ1knc',
+    serviceAccountAuth
+  );
+  // load directly from json file if not in secure environment
+
+  await doc.loadInfo(); // loads document properties and worksheets
+
+  return doc;
+}
+
+function getPureKey(key = '') {
+  return key;
+}
+
+export {
+  localesPath,
+  loadSpreadsheet,
+  getPureKey,
+  ns,
+  lngs,
+  sheetId,
+  columnKeyToHeader,
+  NOT_AVAILABLE_CELL,
+};

--- a/apps/web/translate/index.js
+++ b/apps/web/translate/index.js
@@ -1,6 +1,8 @@
 import { JWT } from 'google-auth-library';
 import { GoogleSpreadsheet } from 'google-spreadsheet';
 import credentials from './credentials.json' assert { type: 'json' };
+// import dotenv from 'dotenv';  
+// dotenv.config();
 
 const ns = 'ko';
 const lngs = ['ko', 'en', 'es'];
@@ -13,6 +15,7 @@ const columnKeyToHeader = {
   'en': '영어',
   'es': '스페인어',
 };
+const googleSheetId = process.env.TRANSLATE_GOOGLE_SHEET_ID;
 
 // Initialize auth - see https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication
 const email = credentials.client_email;
@@ -27,9 +30,10 @@ const serviceAccountAuth = new JWT({
  * getting started from https://theoephraim.github.io/node-google-spreadsheet
  */
 async function loadSpreadsheet() {
+
   // spreadsheet key is the long id in the sheets URL
   const doc = new GoogleSpreadsheet(
-    '1ZTHUZLuSDE9z-398uQDBAZ4ERhcmSHJ22uWJNcJ1knc',
+    googleSheetId,
     serviceAccountAuth
   );
   // load directly from json file if not in secure environment

--- a/apps/web/translate/index.js
+++ b/apps/web/translate/index.js
@@ -1,7 +1,9 @@
 import { JWT } from 'google-auth-library';
 import { GoogleSpreadsheet } from 'google-spreadsheet';
 
-import credentials from './credentials.json' with { type: 'json' };
+const email = process.env.GOOGLE_CLIENT_EMAIL;
+const key = process.env.GOOGLE_PRIVATE_KEY;
+const googleSheetId = process.env.TRANSLATE_GOOGLE_SHEET_ID;
 
 const ns = 'ko';
 const lngs = ['ko', 'en', 'es'];
@@ -14,15 +16,14 @@ const columnKeyToHeader = {
   en: '영어',
   es: '스페인어',
 };
-const googleSheetId = process.env.TRANSLATE_GOOGLE_SHEET_ID;
 
 // Initialize auth - see https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication
-const email = credentials.client_email;
-const key = credentials.private_key.replace(/\\n/g, '\n');
+
+const parsedKey = key.replace(/\\n/g, '\n');
 
 const serviceAccountAuth = new JWT({
   email,
-  key,
+  key: parsedKey,
   scopes: ['https://www.googleapis.com/auth/spreadsheets'],
 });
 /**
@@ -31,8 +32,6 @@ const serviceAccountAuth = new JWT({
 async function loadSpreadsheet() {
   // spreadsheet key is the long id in the sheets URL
   const doc = new GoogleSpreadsheet(googleSheetId, serviceAccountAuth);
-  // load directly from json file if not in secure environment
-
   await doc.loadInfo(); // loads document properties and worksheets
 
   return doc;

--- a/apps/web/translate/index.js
+++ b/apps/web/translate/index.js
@@ -1,8 +1,7 @@
 import { JWT } from 'google-auth-library';
 import { GoogleSpreadsheet } from 'google-spreadsheet';
-import credentials from './credentials.json' assert { type: 'json' };
-// import dotenv from 'dotenv';  
-// dotenv.config();
+
+import credentials from './credentials.json' with { type: 'json' };
 
 const ns = 'ko';
 const lngs = ['ko', 'en', 'es'];
@@ -11,9 +10,9 @@ const sheetId = 0; // your sheet id
 const NOT_AVAILABLE_CELL = '_N/A';
 const columnKeyToHeader = {
   key: '키',
-  'ko': '한글',
-  'en': '영어',
-  'es': '스페인어',
+  ko: '한글',
+  en: '영어',
+  es: '스페인어',
 };
 const googleSheetId = process.env.TRANSLATE_GOOGLE_SHEET_ID;
 
@@ -30,12 +29,8 @@ const serviceAccountAuth = new JWT({
  * getting started from https://theoephraim.github.io/node-google-spreadsheet
  */
 async function loadSpreadsheet() {
-
   // spreadsheet key is the long id in the sheets URL
-  const doc = new GoogleSpreadsheet(
-    googleSheetId,
-    serviceAccountAuth
-  );
+  const doc = new GoogleSpreadsheet(googleSheetId, serviceAccountAuth);
   // load directly from json file if not in secure environment
 
   await doc.loadInfo(); // loads document properties and worksheets

--- a/apps/web/translate/index.js
+++ b/apps/web/translate/index.js
@@ -9,9 +9,9 @@ const sheetId = 0; // your sheet id
 const NOT_AVAILABLE_CELL = '_N/A';
 const columnKeyToHeader = {
   key: '키',
-  'ko-KR': '한글',
-  'en-US': '영어',
-  'es-AR': '스페인어',
+  'ko': '한글',
+  'en': '영어',
+  'es': '스페인어',
 };
 
 // Initialize auth - see https://theoephraim.github.io/node-google-spreadsheet/#/guides/authentication

--- a/apps/web/translate/package.json
+++ b/apps/web/translate/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/apps/web/translate/upload.js
+++ b/apps/web/translate/upload.js
@@ -1,0 +1,129 @@
+// place in translate/upload.js
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+const {
+  loadSpreadsheet,
+  localesPath,
+  getPureKey,
+  lngs,
+  sheetId,
+  columnKeyToHeader,
+  NOT_AVAILABLE_CELL,
+} = await import('./index.js');
+
+const headerValues = ['키', '한글', '영어', '스페인어'];
+
+async function addNewSheet(doc, title, sheetId) {
+  const sheet = await doc.addSheet({
+    sheetId,
+    title,
+    headerValues,
+  });
+
+  return sheet;
+}
+
+async function updateTranslationsFromKeyMapToSheet(doc, keyMap) {
+  const title = 'Your Sheet Title';
+  let sheet = doc.sheetsById[sheetId];
+  if (!sheet) {
+    sheet = await addNewSheet(doc, title, sheetId);
+  }
+
+  const rows = await sheet.getRows();
+
+  // find exsit keys
+  const exsitKeys = {};
+  const addedRows = [];
+  rows.forEach((row) => {
+    const key = row[columnKeyToHeader.key];
+    if (keyMap[key]) {
+      exsitKeys[key] = true;
+    }
+  });
+
+  for (const [key, translations] of Object.entries(keyMap)) {
+    if (!exsitKeys[key]) {
+      const row = {
+        [columnKeyToHeader.key]: key,
+        ...Object.keys(translations).reduce((result, lng) => {
+          const header = columnKeyToHeader[lng];
+          result[header] = translations[lng];
+
+          return result;
+        }, {}),
+      };
+
+      addedRows.push(row);
+    }
+  }
+
+  // upload new keys
+  await sheet.addRows(addedRows);
+}
+
+function toJson(keyMap) {
+  const json = {};
+
+  Object.entries(keyMap).forEach(([__, keysByPlural]) => {
+    for (const [keyWithPostfix, translations] of Object.entries(keysByPlural)) {
+      json[keyWithPostfix] = {
+        ...translations,
+      };
+    }
+  });
+
+  return json;
+}
+
+function gatherKeyMap(keyMap, lng, json) {
+  for (const [keyWithPostfix, translated] of Object.entries(json)) {
+    const key = getPureKey(keyWithPostfix);
+
+    if (!keyMap[key]) {
+      keyMap[key] = {};
+    }
+
+    const keyMapWithLng = keyMap[key];
+    if (!keyMapWithLng[keyWithPostfix]) {
+      keyMapWithLng[keyWithPostfix] = lngs.reduce((initObj, lng) => {
+        initObj[lng] = NOT_AVAILABLE_CELL;
+
+        return initObj;
+      }, {});
+    }
+
+    keyMapWithLng[keyWithPostfix][lng] = translated;
+  }
+}
+
+async function updateSheetFromJson() {
+  const doc = await loadSpreadsheet();
+  const fs = await import('fs');
+  fs.readdir(localesPath, (error, lngs) => {
+    if (error) {
+      console.log('readdir error');
+      // console.error(error);
+      throw error;
+    }
+
+    const keyMap = {};
+
+    lngs.forEach((lng) => {
+      const localeJsonFilePath = `${localesPath}/${lng}`;
+
+      // eslint-disable-next-line no-sync
+      const json = fs.readFileSync(localeJsonFilePath, 'utf8');
+
+      gatherKeyMap(keyMap, lng, JSON.parse(json));
+    });
+
+    updateTranslationsFromKeyMapToSheet(doc, toJson(keyMap));
+  });
+}
+
+(async () => {
+  await updateSheetFromJson();
+})();

--- a/apps/web/translate/upload.js
+++ b/apps/web/translate/upload.js
@@ -127,9 +127,47 @@ async function addHeaderRowToSheet() {
   await sheet.setHeaderRow(headerValues);
 }
 
+async function sortRange() {
+  const doc = await loadSpreadsheet();
+  const sheet = doc.sheetsById[sheetId];
+
+  // 정렬 요청 정의
+  const request = {
+    sortRange: {
+      range: {
+        sheetId: sheet.sheetId, // sheet 객체의 고유 ID
+        startRowIndex: 1, // 헤더 제외 (0-based index)
+        endRowIndex: sheet.rowCount,
+        startColumnIndex: 0, // 첫 번째 열부터
+        endColumnIndex: sheet.columnCount,
+      },
+      sortSpecs: [
+        {
+          dimensionIndex: 0, // 0번째 열 (Key 컬럼)
+          sortOrder: 'ASCENDING', // 오름차순 (DESCENDING 도 가능)
+        },
+        // 필요하다면 여러 열 기준 정렬 추가 가능
+        // {
+        //   dimensionIndex: 1,
+        //   sortOrder: 'DESCENDING',
+        // },
+      ],
+    },
+  };
+
+  try {
+    await doc.sheetsApi.post(`:batchUpdate`, {
+      json: { requests: [request] },
+    });
+    console.log('시트 정렬 성공 ✅');
+  } catch (error) {
+    console.error('시트 정렬 중 오류 발생 ❌:', error);
+  }
+}
+
 async function updateSheetFromJson() {
-  await resetSheet();
-  await addHeaderRowToSheet();
+  // await resetSheet();
+  // await addHeaderRowToSheet();
 
   const doc = await loadSpreadsheet();
   const fs = await import('fs');
@@ -151,6 +189,8 @@ async function updateSheetFromJson() {
     });
 
     updateTranslationsFromKeyMapToSheet(doc, toJson(keyMap));
+
+    sortRange();
   });
 }
 

--- a/apps/web/translate/upload.js
+++ b/apps/web/translate/upload.js
@@ -26,18 +26,18 @@ async function updateTranslationsFromKeyMapToSheet(doc, keyMap) {
   }
 
   const rows = await sheet.getRows();
-  // find exsit keys
-  const exsitKeys = {};
+  // find exist keys
+  const existKeys = {};
   const addedRows = [];
   rows.forEach((row) => {
     const key = row._rawData[0];
     if (keyMap[key]) {
-      exsitKeys[key] = true;
+      existKeys[key] = true;
     }
   });
 
   for (const [key, translations] of Object.entries(keyMap)) {
-    if (!exsitKeys[key]) {
+    if (!existKeys[key]) {
       const row = {
         [columnKeyToHeader.key]: key,
         ...Object.keys(translations).reduce((result, lng) => {
@@ -146,11 +146,6 @@ async function sortRange() {
           dimensionIndex: 0, // 0번째 열 (Key 컬럼)
           sortOrder: 'ASCENDING', // 오름차순 (DESCENDING 도 가능)
         },
-        // 필요하다면 여러 열 기준 정렬 추가 가능
-        // {
-        //   dimensionIndex: 1,
-        //   sortOrder: 'DESCENDING',
-        // },
       ],
     },
   };
@@ -166,9 +161,6 @@ async function sortRange() {
 }
 
 async function updateSheetFromJson() {
-  // await resetSheet();
-  // await addHeaderRowToSheet();
-
   const doc = await loadSpreadsheet();
   const fs = await import('fs');
   fs.readdir(localesPath, (error, lngs) => {
@@ -189,11 +181,17 @@ async function updateSheetFromJson() {
     });
 
     updateTranslationsFromKeyMapToSheet(doc, toJson(keyMap));
-
+    // 키 업데이트 후 정렬하는 로직 추가
     sortRange();
   });
 }
 
 (async () => {
-  await updateSheetFromJson();
+  try {
+    await updateSheetFromJson();
+    console.log('번역 키 업로드 완료 ✅');
+  } catch (error) {
+    console.error('번역 키 업로드 실패 ❌:', error);
+    process.exit(1);
+  }
 })();

--- a/apps/web/translate/upload.js
+++ b/apps/web/translate/upload.js
@@ -5,11 +5,9 @@ const {
   lngs,
   sheetId,
   columnKeyToHeader,
-  NOT_AVAILABLE_CELL,
 } = await import('./index.js');
 
-const headerValues = ['키', '한글', '영어', '스페인어'];
-
+const headerValues = Object.values(columnKeyToHeader);
 async function addNewSheet(doc, title, sheetId) {
   const sheet = await doc.addSheet({
     sheetId,
@@ -28,7 +26,6 @@ async function updateTranslationsFromKeyMapToSheet(doc, keyMap) {
   }
 
   const rows = await sheet.getRows();
-
   // find exsit keys
   const exsitKeys = {};
   const addedRows = [];
@@ -95,6 +92,8 @@ function flattenObject(obj, prefix = '') {
 function gatherKeyMap(keyMap, lng, json) {
   // 중첩된 JSON을 평면화
   const flattenedJson = flattenObject(json);
+
+  // message 파일 이름에서 .json 제거
   lng = lng.replace('.json', '');
 
   for (const [keyWithPostfix, translated] of Object.entries(flattenedJson)) {
@@ -116,13 +115,27 @@ function gatherKeyMap(keyMap, lng, json) {
   }
 }
 
+async function resetSheet() {
+  const doc = await loadSpreadsheet();
+  const sheet = doc.sheetsById[sheetId];
+  sheet.clear();
+}
+
+async function addHeaderRowToSheet() {
+  const doc = await loadSpreadsheet();
+  const sheet = doc.sheetsById[sheetId];
+  await sheet.setHeaderRow(headerValues);
+}
+
 async function updateSheetFromJson() {
+  await resetSheet();
+  await addHeaderRowToSheet();
+
   const doc = await loadSpreadsheet();
   const fs = await import('fs');
   fs.readdir(localesPath, (error, lngs) => {
     if (error) {
       console.log('readdir error');
-      // console.error(error);
       throw error;
     }
 

--- a/apps/web/translate/upload.js
+++ b/apps/web/translate/upload.js
@@ -19,7 +19,7 @@ async function addNewSheet(doc, title, sheetId) {
 }
 
 async function updateTranslationsFromKeyMapToSheet(doc, keyMap) {
-  const title = 'Your Sheet Title';
+  const title = 'Lococo Translate sheet';
   let sheet = doc.sheetsById[sheetId];
   if (!sheet) {
     sheet = await addNewSheet(doc, title, sheetId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       es-toolkit:
         specifier: ^1.39.6
         version: 1.39.7
+      google-auth-library:
+        specifier: ^10.3.0
+        version: 10.3.0
+      google-spreadsheet:
+        specifier: ^5.0.2
+        version: 5.0.2(google-auth-library@10.3.0)
       install:
         specifier: ^0.13.0
         version: 0.13.0
@@ -2243,6 +2249,9 @@ packages:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -2263,6 +2272,9 @@ packages:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -2491,6 +2503,10 @@ packages:
     resolution: {integrity: sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==}
     engines: {node: '>=4'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -2654,6 +2670,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.181:
     resolution: {integrity: sha512-+ISMj8OIQ+0qEeDj14Rt8WwcTOiqHyAB+5bnK1K7xNNLjBJ4hRCQfUkw8RWtcLbfBzDwc15ZnKH0c7SNOfwiyA==}
 
@@ -2708,6 +2727,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
 
   es-toolkit@1.39.7:
     resolution: {integrity: sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==}
@@ -2908,6 +2930,9 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -2945,6 +2970,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2985,6 +3014,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -3011,6 +3044,14 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@7.1.1:
+    resolution: {integrity: sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@7.0.1:
+    resolution: {integrity: sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3091,6 +3132,22 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-auth-library@10.3.0:
+    resolution: {integrity: sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.1:
+    resolution: {integrity: sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==}
+    engines: {node: '>=14'}
+
+  google-spreadsheet@5.0.2:
+    resolution: {integrity: sha512-8ugGYGsy6BLl6d4z2zwllEv8hFB2IVcCNAUYT/seo4DU7Pk6m79qv+qRxE2cE8bxbf4S13T5fzrjcPhbk2ogsw==}
+    peerDependencies:
+      google-auth-library: '>=8.8.0'
+    peerDependenciesMeta:
+      google-auth-library:
+        optional: true
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3104,6 +3161,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -3428,6 +3489,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3456,12 +3520,22 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  ky@1.10.0:
+    resolution: {integrity: sha512-YRPCzHEWZffbfvmRrfwa+5nwBHwZuYiTrfDX0wuhGBPV0pA/zCqcOq93MDssON/baIkpYbvehIX5aLpMxrRhaA==}
+    engines: {node: '>=18'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3757,6 +3831,11 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-h2@2.3.0:
     resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
     engines: {node: 4.x || >=6.0.0}
@@ -3772,6 +3851,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-plop@0.26.3:
     resolution: {integrity: sha512-Cov028YhBZ5aB7MdMWJEmwyBig43aGL5WT4vdoB28Oitau1zZAcHUn8Sgfk9HM33TqhtLJ9PlM/O0Mv+QpV/4Q==}
@@ -4918,6 +5001,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -6875,6 +6962,8 @@ snapshots:
     dependencies:
       open: 8.4.2
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -6902,6 +6991,8 @@ snapshots:
       electron-to-chromium: 1.5.181
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
@@ -7140,6 +7231,8 @@ snapshots:
 
   dashify@2.0.0: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-uri-to-buffer@6.0.2: {}
 
   data-view-buffer@1.0.2:
@@ -7293,6 +7386,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   electron-to-chromium@1.5.181: {}
 
   emoji-regex@8.0.0: {}
@@ -7412,6 +7509,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.39.10: {}
 
   es-toolkit@1.39.7: {}
 
@@ -7683,6 +7782,8 @@ snapshots:
 
   exsolve@1.0.7: {}
 
+  extend@3.0.2: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -7722,6 +7823,11 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   figures@3.2.0:
     dependencies:
@@ -7764,6 +7870,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -7790,6 +7900,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@7.0.1:
+    dependencies:
+      gaxios: 7.1.1
+      google-logging-utils: 1.1.1
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -7900,6 +8026,27 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-auth-library@10.3.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.1
+      gcp-metadata: 7.0.1
+      google-logging-utils: 1.1.1
+      gtoken: 8.0.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.1: {}
+
+  google-spreadsheet@5.0.2(google-auth-library@10.3.0):
+    dependencies:
+      es-toolkit: 1.39.10
+      ky: 1.10.0
+    optionalDependencies:
+      google-auth-library: 10.3.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -7910,6 +8057,13 @@ snapshots:
       tinygradient: 1.1.5
 
   graphemer@1.4.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.1
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   handlebars@4.7.8:
     dependencies:
@@ -8251,6 +8405,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -8278,11 +8436,24 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  ky@1.10.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -8524,6 +8695,8 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-h2@2.3.0:
     dependencies:
       http2-client: 1.3.5
@@ -8533,6 +8706,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-plop@0.26.3:
     dependencies:
@@ -9846,6 +10025,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary
다국어 서비스를 위한 번역 주체를 외부로 두기 위해 구글시트를 활용한 번역 파이프라인을 구축하고 자동화
<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #312 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks
<!-- 작업한 내용을 상세히 작성해주세요 -->
- [x] google-spreadsheet api를 js로 래핑한 [라이브러리](https://www.npmjs.com/package/google-spreadsheet)를 통해 lococo 번역 구글 시트 연결 및 세팅 
- [x] google auth library를 통해 사용자 인증 (google clude 사용자 인증정보 등록 및 credentials 세팅)
- [x] ko, en, es 파일의 중첩 객체 json형식을 google sheet로 업로드하는 upload.js 함수 구현
- [x] 구글 시트에서 번역을 마친후 해당 key와 value 값을 다시 중첩객체로 parsing한 후 json 파일에 추가하는 함수 download.js 구현 

## To Reviewer
env에 구글 스프레드시트 id를, 로컬 환경에는 credentail.json을 추가해주셔야합니다!  x
=> 변경된 부분 : env에 구글 스프레드 시트 id와 GOOGLE_CLIENT_EMAIL, GOOGLE_PRIVATE_KEY 를 추가해주셔야 합니다! 
해당 내용은 다음 회의와 노션으로 공유드리겠습니다.

upload 함수는 현재 가지고 있는 ko, en, es등의 번역 파일을 구글 스프레드시트에 업로드하는 용도입니다. 즉 개발을 마친 후 새로 생긴 key가 있다면 PR을 작성하기 전 `pnpm translate:upload` script를 통해 새로 추가된 키를 시트에 업로드해주셔야합니다. 

download함수는 구글스프레드시트에 존재하는 내용을 ko, en, es 파일로 다운로드하는 용도의 함수입니다. PR을 머지하기 전 `pnpm translate:download` script를 통해 번역된 key들을 다운로드하고 머지해주시면 됩니다. 

개발 프로세스 과정은 
개발 진행 -> 진행과정에서 모든 text는 번역 키에 추가 -> 개발 완료 -> PR과 동시에 구글 스프레드시트에 upload 후 번역 요청 -> 번역 완료와 코드리뷰 반영 완료 후 해당 브랜치에서 download -> 번역 검토 후 머지 
입니다!


<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Google 스프레드시트와 연동해 로케일 JSON을 내려받아 갱신하고, 로컬 JSON을 시트에 업로드해 자동으로 정렬하는 번역 동기화 워크플로 추가.

- **Chores**
  - Google Sheets 연동용 의존성 추가 및 번역 패키지의 ES 모듈 방식 활성화(type: module).
  - 번역 스크립트 실행 항목 및 관련 실행 환경 설정 추가, 불필요 파일 무시 규칙 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->