### PR TITLE
Feat(*): 폰트 스타일 지정 방식 변경(font는 locale기반 자동으로, 키워드만 입력하도록 변경)

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-header.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-header.tsx
@@ -16,7 +16,7 @@ export default function HomeSectionHeader({
         {children}
       </h3>
       {moreInfoUrl && (
-        <Link href={moreInfoUrl} className="jp-title2 font-[700]">
+        <Link href={moreInfoUrl} className="title2 font-[700]">
           더보기
         </Link>
       )}

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-header.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-header.tsx
@@ -12,7 +12,7 @@ export default function HomeSectionHeader({
 }: HomeSectionHeaderProps) {
   return (
     <section className="mt-[6rem] flex justify-between">
-      <h3 className="jp-head1 flex items-center gap-[1.2rem] font-[700]">
+      <h3 className="head1 flex items-center gap-[1.2rem] font-[700]">
         {children}
       </h3>
       {moreInfoUrl && (

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-review.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-review.tsx
@@ -33,7 +33,7 @@ export default function HomeSectionReview({
 
   return (
     <div className={cn(`mt-[3.2rem] flex flex-col gap-[3.2rem]`, className)}>
-      <p className="jp-head3 font-[700]">
+      <p className="head3 font-[700]">
         {type === 'video' && '動画レビュー'}
         {type === 'image' && '写真付きレビュー'}
       </p>
@@ -65,7 +65,7 @@ export default function HomeSectionReview({
                 router.push(`/product-detail/${review.productId}`);
               }}
             >
-              <div className="jp-title3 flex items-center gap-[0.8rem] font-bold">
+              <div className="title3 flex items-center gap-[0.8rem] font-bold">
                 <SvgArrowOutward />
                 見に行く
               </div>

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-update-date.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-update-date.tsx
@@ -9,10 +9,10 @@ export default function HomeUpdateDate() {
   const [year, month, day] = japanDate.split('/');
 
   return (
-    <div className="text-jp-body2 mt-[4rem] flex justify-end font-medium text-gray-600">
-      更新日時 :<span className="text-en-body1">{year}</span>年
-      <span className="text-en-body1">{month}</span>月
-      <span className="text-en-body1">{day}</span>日
+    <div className="body2 mt-[4rem] flex justify-end font-medium text-gray-600">
+      更新日時 :<span className="body1">{year}</span>年
+      <span className="body1">{month}</span>月
+      <span className="body1">{day}</span>日
     </div>
   );
 }

--- a/apps/web/app/[locale]/(with-layout)/login-google/components/loginButton.tsx
+++ b/apps/web/app/[locale]/(with-layout)/login-google/components/loginButton.tsx
@@ -8,7 +8,7 @@ export default function LoginButton() {
       <span className="absolute left-[2rem] flex items-center">
         <SvgGoogle size={20} />
       </span>
-      <span className="inter-body1 flex w-full justify-center pl-[2rem] font-bold text-[#1F1F1F]">
+      <span className="body1 flex w-full justify-center pl-[2rem] font-bold text-[#1F1F1F]">
         Continue with Google
       </span>
     </button>

--- a/apps/web/app/[locale]/(with-layout)/login-google/components/loginTitle.tsx
+++ b/apps/web/app/[locale]/(with-layout)/login-google/components/loginTitle.tsx
@@ -5,10 +5,10 @@ export default function LoginTitle({
 }) {
   return (
     <section className="text-center">
-      <h1 className="inter-head3 mb-[1.6rem] font-bold text-pink-500">
+      <h1 className="head3 mb-[1.6rem] font-bold text-pink-500">
         Welcome to Lococo!
       </h1>
-      <div className="inter-caption2 font-medium text-gray-800">
+      <div className="caption2 font-medium text-gray-800">
         {authType === 'login' ? (
           <p>Log in to your Google account right away</p>
         ) : (

--- a/apps/web/app/[locale]/(with-layout)/login/components/loginButton.tsx
+++ b/apps/web/app/[locale]/(with-layout)/login/components/loginButton.tsx
@@ -15,7 +15,7 @@ export default function LoginButton() {
   return (
     <Link
       href={lineLoginUrl}
-      className="jp-body1 relative mt-[12rem] flex h-[4.8rem] cursor-pointer items-center rounded-[0.6rem] bg-[#06C755] pl-[5.4rem] pr-[5.4rem] font-bold text-white"
+      className="body1 relative mt-[12rem] flex h-[4.8rem] cursor-pointer items-center rounded-[0.6rem] bg-[#06C755] pl-[5.4rem] pr-[5.4rem] font-bold text-white"
     >
       <span className="absolute left-[2.1rem] flex items-center">
         <SvgLine size={20} />

--- a/apps/web/app/[locale]/(with-layout)/login/components/loginTitle.tsx
+++ b/apps/web/app/[locale]/(with-layout)/login/components/loginTitle.tsx
@@ -1,10 +1,10 @@
 export default function LoginTitle() {
   return (
     <>
-      <h1 className="jp-head3 mb-[1.4rem] font-bold text-pink-500">
+      <h1 className="head3 mb-[1.4rem] font-bold text-pink-500">
         会員ログイン
       </h1>
-      <p className="jp-body2 text-gray-700">LINEアカウントですぐにログイン</p>
+      <p className="body2 text-gray-700">LINEアカウントですぐにログイン</p>
     </>
   );
 }

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)delete-review/page.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)delete-review/page.tsx
@@ -46,11 +46,11 @@ export default function DeleteReviewModal() {
   return (
     <Modal className="w-[40rem]">
       <Modal.Header className="h-[4.8rem] font-[700]">
-        <h1 className="en-body1">レビューを削除</h1>
+        <h1 className="body1">レビューを削除</h1>
       </Modal.Header>
       <Modal.Body className="h-[9.4rem] gap-[0.8rem] p-[1.6rem]">
-        <p className="jp-title2 font-bold">レビューを削除しますか？</p>
-        <p className="jp-caption3 text-gray-00 font-[400]">
+        <p className="title2 font-bold">レビューを削除しますか？</p>
+        <p className="caption3 text-gray-00 font-[400]">
           削除すると、このレビューは元に戻せません。
         </p>
       </Modal.Body>
@@ -61,7 +61,7 @@ export default function DeleteReviewModal() {
             variant="filled"
             size="lg"
             rounded="sm"
-            className="jp-title2 w-[17.8rem] text-pink-500"
+            className="title2 w-[17.8rem] text-pink-500"
             onClick={handleCancel}
           >
             キャンセル
@@ -71,7 +71,7 @@ export default function DeleteReviewModal() {
             variant="filled"
             size="lg"
             rounded="sm"
-            className="jp-title2 w-[17.8rem] text-white"
+            className="title2 w-[17.8rem] text-white"
             onClick={handleDelete}
           >
             削除

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/media-upload.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/media-upload.tsx
@@ -84,7 +84,7 @@ export default function MediaUpload({
       label="写真または動画をアップロードしてください"
       className="flex-col border-b border-gray-400"
     >
-      <p className="jp-caption3 text-blue mt-[0.8rem] pb-[2.4rem]">
+      <p className="caption3 text-blue mt-[0.8rem] pb-[2.4rem]">
         写真（最大5枚）または動画（1件）のみアップできます。
       </p>
 

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/product-info.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/product-info.tsx
@@ -19,8 +19,8 @@ export default function ProductInfo({
         />
       )}
       <div className="flex flex-col items-start gap-[0.4rem]">
-        <h3 className="jp-body1 font-bold text-gray-800">{productName}</h3>
-        <p className="jp-body2 text-gray-800">{brandName}</p>
+        <h3 className="body1 font-bold text-gray-800">{productName}</h3>
+        <p className="body2 text-gray-800">{brandName}</p>
       </div>
     </div>
   );

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/product-option.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/product-option.tsx
@@ -39,10 +39,10 @@ export default function ProductOption({
         value={value ? String(value) : ''}
         onValueChange={handleValueChange}
       >
-        <SelectTrigger className="jp-body2">
+        <SelectTrigger className="body2">
           <SelectValue placeholder="オプション" />
         </SelectTrigger>
-        <SelectContent className="scrollbar-hide jp-body2">
+        <SelectContent className="scrollbar-hide body2">
           {options.map(({ id, optionName }) => (
             <SelectItem hover value={String(id)} key={id}>
               {optionName}

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/receipt-certification.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/components/receipt-certification.tsx
@@ -51,7 +51,7 @@ export default function ReceiptCertification({ file, onChange, error }: Props) {
       label="購入証明写真をアップロードしてください"
       className="flex-col border-b border-gray-400"
     >
-      <p className="jp-caption3 text-blue mt-[0.8rem] pb-[2.4rem]">
+      <p className="caption3 text-blue mt-[0.8rem] pb-[2.4rem]">
         レシート・オンライン購入のキャプチャなど。
       </p>
 

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/page.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/@modal/(.)write-review/page.tsx
@@ -71,7 +71,7 @@ export default function WriteReviewModal() {
   return (
     <Modal className="size-[70rem] rounded-[0.8rem]" onClose={handleClose}>
       <Modal.Header className="sticky top-0 flex justify-between">
-        <h2 className="jp-body1 font-bold text-gray-800">レビューを書く</h2>
+        <h2 className="body1 font-bold text-gray-800">レビューを書く</h2>
         <IconButton
           icon={<SvgClose />}
           size="sm"
@@ -128,7 +128,7 @@ export default function WriteReviewModal() {
           variant="filled"
           size="lg"
           color="primary"
-          className="jp-title2 w-full px-[1.6rem] py-[1.2rem]"
+          className="title2 w-full px-[1.6rem] py-[1.2rem]"
           rounded="sm"
           onClick={onSubmit}
           disabled={!isFormValid}

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/comment-box.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/comment-box.tsx
@@ -35,7 +35,7 @@ export default function CommentBox({ text, type }: CommentBoxProps) {
         ) : (
           <SvgBad />
         )}
-        <span className="jp-body1 font-bold text-gray-600">
+        <span className="body1 font-bold text-gray-600">
           {type === 'positive' ? '良かったです' : '気になる点'}
         </span>
       </div>
@@ -44,7 +44,7 @@ export default function CommentBox({ text, type }: CommentBoxProps) {
       <div
         ref={textRef}
         className={cn(
-          'jp-body2 break-all text-gray-800',
+          'body2 break-all text-gray-800',
           !isExpanded && 'line-clamp-3 max-h-[6.6rem] overflow-hidden'
         )}
       >
@@ -60,7 +60,7 @@ export default function CommentBox({ text, type }: CommentBoxProps) {
           onClick={() => setIsExpanded(!isExpanded)}
         >
           <SvgAdd />
-          <span className="jp-title3 font-bold">もっと見る</span>
+          <span className="title3 font-bold">もっと見る</span>
         </Button>
       )}
       {isExpanded && (
@@ -72,7 +72,7 @@ export default function CommentBox({ text, type }: CommentBoxProps) {
           onClick={() => setIsExpanded(!isExpanded)}
         >
           <SvgRemove />
-          <span className="jp-title3 font-bold">閉じる</span>
+          <span className="title3 font-bold">閉じる</span>
         </Button>
       )}
     </div>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-bread-crumb-section.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-bread-crumb-section.tsx
@@ -32,7 +32,7 @@ export default function ProductBreadCrumbSection({
     <>
       {middleCategory && (
         <Breadcrumb className="flex h-[5.2rem] min-w-[1366px] items-center self-stretch bg-gray-100 opacity-80">
-          <BreadcrumbList className="jp-body2 mx-auto w-[1366px] px-[11.9rem] text-gray-600">
+          <BreadcrumbList className="body2 mx-auto w-[1366px] px-[11.9rem] text-gray-600">
             <BreadcrumbItem className="flex aspect-square h-[4.4rem] w-[4.4rem] items-center justify-center p-[1rem]">
               <SvgHomeFill />
             </BreadcrumbItem>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-info-tab.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-info-tab.tsx
@@ -34,7 +34,7 @@ export default function ProductInfoTab({
         ></Tab>
       </TabContainer>
 
-      <div className="text-jp-body1 border-b-[0.1rem] border-gray-300 py-[4rem] text-gray-700">
+      <div className="body1 border-b-[0.1rem] border-gray-300 py-[4rem] text-gray-700">
         {activeTab === 'productDetail' ? productDetail : ingredients}
       </div>
     </div>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-info.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/product-info.tsx
@@ -81,8 +81,8 @@ export default function ProductInfo({
       <div className="flex w-[48rem] flex-col gap-[1.2rem]">
         <div className="flex justify-between gap-[0.4rem]">
           <div className="flex flex-col gap-[0.6rem]">
-            <p className="jp-title3 font-bold text-gray-700">{brandName}</p>
-            <h1 className="jp-head3 font-bold text-gray-800">{productName}</h1>
+            <p className="title3 font-bold text-gray-700">{brandName}</p>
+            <h1 className="head3 font-bold text-gray-800">{productName}</h1>
           </div>
           <IconButton
             onClick={() => handleLikeClick(productId)}
@@ -103,27 +103,25 @@ export default function ProductInfo({
           />
         </div>
         <div className="flex flex-col gap-[0.8rem]">
-          <p className="text-red en-head2 font-bold">
-            ¥{formatJPY(normalPrice)}
-          </p>
-          <p className="jp-body2 text-gray-600"> {unit}</p>
+          <p className="text-red head2 font-bold">¥{formatJPY(normalPrice)}</p>
+          <p className="body2 text-gray-600"> {unit}</p>
           <div className="flex items-center gap-[0.4rem]">
             <SvgStar className="fill-yellow" />
-            <span className="en-body1 text-gray-800">
+            <span className="body1 text-gray-800">
               {rating}/{MAX_RATING}
             </span>
-            <span className="en-body1 text-gray-600">({reviewCount})</span>
+            <span className="body1 text-gray-600">({reviewCount})</span>
           </div>
         </div>
         {productOptions.length > 0 && (
           <Select>
             <SelectTrigger
-              className="jp-body2 text-gray-800"
+              className="body2 text-gray-800"
               disabled={productOptions.length === 0}
             >
               <SelectValue placeholder="オプション" />
             </SelectTrigger>
-            <SelectContent className="jp-body2 text-gray-800">
+            <SelectContent className="body2 text-gray-800">
               {productOptions.map((option) => (
                 <SelectItem value={option.optionName} key={option.id} disabled>
                   {option.optionName}
@@ -149,7 +147,7 @@ export default function ProductInfo({
               href={q10Url}
               target="_blank"
               rel="noopener noreferrer"
-              className="jp-title2 flex items-center gap-[0.8rem] font-bold"
+              className="title2 flex items-center gap-[0.8rem] font-bold"
             >
               <SvgPurchase /> Qoo10
             </Link>
@@ -167,7 +165,7 @@ export default function ProductInfo({
               href={oliveYoungUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="jp-title2 flex items-center gap-[0.8rem] font-bold"
+              className="title2 flex items-center gap-[0.8rem] font-bold"
             >
               <SvgPurchase /> Olive Young
             </Link>
@@ -178,7 +176,7 @@ export default function ProductInfo({
           variant="filled"
           rounded="sm"
           size="lg"
-          className="jp-title2 font-bold"
+          className="title2 font-bold"
           onClick={() => handleClickReviewBtn()}
         >
           <SvgWrite /> レビューを書く

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/review-list.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/review-list.tsx
@@ -27,7 +27,7 @@ export default function ReviewList() {
   const reviewListData = reviewList?.imageReviews;
   return (
     <div className="flex flex-col gap-[3.2rem]">
-      <h2 className="jp-head3 font-bold">写真付きレビュー</h2>
+      <h2 className="head3 font-bold">写真付きレビュー</h2>
       {reviewListData && reviewListData.length > 0 ? (
         reviewListData.map((review) => (
           <Review
@@ -55,7 +55,7 @@ export default function ReviewList() {
         <>
           <div className="flex h-[31.1rem] flex-col items-center justify-center gap-[2.4rem]">
             <SvgImgPhoto size={100} className="fill-pink-300" />
-            <p className="jp-body1 font-[700]">
+            <p className="body1 font-[700]">
               登録された動画レビューはありません。
             </p>
           </div>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/review.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/review.tsx
@@ -115,7 +115,7 @@ export default function Review({
         </div>
         <div className="flex items-center justify-end">
           <div className="flex items-center gap-[1.2rem]">
-            <p className="jp-title3 font-bold text-gray-800">参考になった</p>
+            <p className="title3 font-bold text-gray-800">参考になった</p>
 
             <ReactionToggle
               variant="horizontal"
@@ -125,7 +125,7 @@ export default function Review({
             >
               <div className="flex items-center gap-[0.4rem]">
                 <SvgGoodOutline className="transition-colors duration-300 group-hover:text-gray-500" />
-                <p className="en-body1 text-gray-800 transition-colors duration-300 group-hover:text-gray-500">
+                <p className="body1 text-gray-800 transition-colors duration-300 group-hover:text-gray-500">
                   {likeCount}
                 </p>
               </div>
@@ -137,7 +137,7 @@ export default function Review({
       <div className="flex w-[26.4rem] flex-col items-stretch gap-[1.2rem]">
         <div className="flex items-center gap-[1.2rem]">
           <Avatar src={profileImageUrl} />
-          <p className="en-title2 w-full text-gray-800">{authorName}</p>
+          <p className="title2 w-full text-gray-800">{authorName}</p>
           {(isMine || isAdmin) && (
             <IconButton
               onClick={handleDeleteReview}
@@ -152,7 +152,7 @@ export default function Review({
 
         <div className="flex h-full flex-col gap-[1.2rem]">
           <Star rating={Number(rating)} />
-          <div className="jp-caption1 flex gap-[0.6rem] text-gray-600">
+          <div className="caption1 flex gap-[0.6rem] text-gray-600">
             <span className="inline-flex w-[6.7rem] flex-shrink-0">
               オプション:
             </span>
@@ -161,7 +161,7 @@ export default function Review({
           {receiptUploaded && <Tag text={'レシート'} className="inline-flex" />}
         </div>
 
-        <p className="en-caption1 self-end text-gray-600">
+        <p className="caption1 self-end text-gray-600">
           {dayjs(writtenTime).format('YYYY年MM月DD日')}
         </p>
       </div>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/star-rating.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/star-rating.tsx
@@ -25,33 +25,29 @@ export default function StarRating({
   const { isLoggedIn } = useAuth();
   return (
     <div className="flex flex-col gap-[3.2rem]">
-      <h2 className="text-jp-head2 inline-flex items-center gap-[1.2rem] font-bold">
+      <h2 className="head2 inline-flex items-center gap-[1.2rem] font-bold">
         <SvgJapaneseReview size={24} className="fill-red" /> 日本人レビュー
       </h2>
 
       <div className="flex h-[25.6rem] w-full items-center justify-between rounded-[1.2rem] bg-gray-100 px-[8rem] py-[4rem]">
         <div className="flex gap-[2rem]">
-          <span className="en-head1 font-bold text-gray-800">{rating}</span>
+          <span className="head1 font-bold text-gray-800">{rating}</span>
           <div className="flex flex-col items-center gap-[0.6rem]">
             <Star color="black" rating={rating} />
             <div className="flex gap-[0.4rem]">
-              <span className="en-title3 font-bold text-gray-600">
+              <span className="title3 font-bold text-gray-600">
                 {reviewCount}
               </span>
-              <span className="jp-title3 font-bold text-gray-600">
-                レビュー
-              </span>
+              <span className="title3 font-bold text-gray-600">レビュー</span>
             </div>
           </div>
         </div>
         <div className="flex flex-col gap-[1.4rem]">
           {starPercent.map(({ percent, score }, index) => (
             <div className="flex items-center gap-[1.6rem]" key={index}>
-              <span className="en-title3 font-bold text-gray-600">{score}</span>
+              <span className="title3 font-bold text-gray-600">{score}</span>
               <Progress value={percent} width="52rem"></Progress>
-              <span className="en-title3 font-bold text-gray-600">
-                {percent}%
-              </span>
+              <span className="title3 font-bold text-gray-600">{percent}%</span>
             </div>
           ))}
         </div>
@@ -66,7 +62,7 @@ export default function StarRating({
               : '/login'
           }
         >
-          <span className="jp-title2 inline-flex items-center gap-[0.8rem]">
+          <span className="title2 inline-flex items-center gap-[0.8rem]">
             <SvgWrite />
             レビューを書く
           </span>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/user-upload-video-carousel.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/user-upload-video-carousel.tsx
@@ -57,7 +57,7 @@ export default function UserUploadVideoCarousel() {
 
   return (
     <div className="flex flex-col gap-[3.2rem]">
-      <h2 className="text-jp-head2 inline-flex items-center gap-[1.2rem] font-bold">
+      <h2 className="head2 inline-flex items-center gap-[1.2rem] font-bold">
         動画レビュー
       </h2>
       <div className="relative h-[35.2rem] w-full">
@@ -123,7 +123,7 @@ export default function UserUploadVideoCarousel() {
         ) : (
           <div className="flex h-full flex-col items-center justify-center gap-[2.4rem]">
             <SvgImgVideo size={100} className="fill-pink-300" />
-            <p className="jp-body1 font-[700]">
+            <p className="body1 font-[700]">
               登録された動画レビューはありません。
             </p>
           </div>

--- a/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/youtube-carousel.tsx
+++ b/apps/web/app/[locale]/(with-layout)/product-detail/[productId]/components/youtube-carousel.tsx
@@ -54,7 +54,7 @@ export default function YoutubeCarousel({
 
   return (
     <div className="flex flex-col gap-[3.2rem]">
-      <h2 className="text-jp-head2 inline-flex items-center gap-[1.2rem] font-bold text-gray-800">
+      <h2 className="head2 inline-flex items-center gap-[1.2rem] font-bold text-gray-800">
         <SvgKoreanReview size={24} /> 韓国ユーチューバーレビュー
       </h2>
       <div className="relative h-[31.1rem]">
@@ -116,7 +116,7 @@ export default function YoutubeCarousel({
         ) : (
           <div className="flex h-[31.1rem] w-full flex-col items-center justify-center gap-[2.4rem]">
             <SvgImgVideo size={100} className="fill-pink-300" />
-            <p className="jp-body1 font-[700]">
+            <p className="body1 font-[700]">
               登録された韓国ユーチューバーレビューはありません。
             </p>
           </div>

--- a/apps/web/app/[locale]/(with-layout)/search/components/not-found-section.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/not-found-section.tsx
@@ -15,8 +15,8 @@ export default function NotFoundSection({
         'flex w-full flex-col items-center justify-center py-[6rem]'
       )}
     >
-      <p className="jp-body1 font-bold text-gray-800">検索結果がありません。</p>
-      <p className="jp-caption font-bold text-gray-600">
+      <p className="body1 font-bold text-gray-800">検索結果がありません。</p>
+      <p className="caption font-bold text-gray-600">
         ほかのキーワードを入力してください。
       </p>
     </div>

--- a/apps/web/app/[locale]/(with-layout)/search/components/option-selector.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/option-selector.tsx
@@ -28,7 +28,7 @@ export default function OptionSelector({
             onClick={() => handleClickTab(value)}
             className={cn(
               'flex h-[6rem] w-full items-center justify-center border-b-2 bg-white px-[2rem] py-[1rem] font-bold',
-              `${isSelected ? 'en-title2 border-gray-800' : 'jp-title2 border-gray-300'}`
+              `${isSelected ? 'title2 border-gray-800' : 'title2 border-gray-300'}`
             )}
           >
             {SEARCH_OPTION[value]}

--- a/apps/web/app/[locale]/(with-layout)/search/components/product-not-found.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/product-not-found.tsx
@@ -1,8 +1,8 @@
 export default function ProductNotFoundSection() {
   return (
     <div className="flex min-h-[50rem] w-full flex-col items-center justify-center py-[6rem]">
-      <p className="jp-body1 font-bold text-gray-800">検索結果がありません。</p>
-      <p className="jp-caption font-bold text-gray-600">
+      <p className="body1 font-bold text-gray-800">検索結果がありません。</p>
+      <p className="caption font-bold text-gray-600">
         ほかのキーワードを入力してください。
       </p>
     </div>

--- a/apps/web/app/[locale]/(with-layout)/search/components/review-not-found.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/review-not-found.tsx
@@ -1,8 +1,8 @@
 export default function ReviewNotFoundSection() {
   return (
     <div className="flex min-h-[50rem] w-full flex-col items-center justify-center gap-[1.2rem] self-stretch py-[6rem]">
-      <p className="jp-body1 font-bold text-gray-800">検索結果がありません。</p>
-      <p className="jp-caption font-bold text-gray-600">
+      <p className="body1 font-bold text-gray-800">検索結果がありません。</p>
+      <p className="caption font-bold text-gray-600">
         ほかのキーワードを入力してください。
       </p>
     </div>

--- a/apps/web/app/[locale]/(with-layout)/search/components/search-bread-crumb-section.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/search-bread-crumb-section.tsx
@@ -30,7 +30,7 @@ export default function SearchBreadCrumbSection({
     <>
       {middleCategory && (
         <Breadcrumb className="flex h-[5.2rem] min-w-[1366px] items-center self-stretch bg-gray-100 opacity-80">
-          <BreadcrumbList className="jp-body2 mx-auto w-[1366px] px-[11.9rem] text-gray-600">
+          <BreadcrumbList className="body2 mx-auto w-[1366px] px-[11.9rem] text-gray-600">
             <BreadcrumbItem className="flex aspect-square h-[4.4rem] w-[4.4rem] items-center justify-center p-[1rem]">
               <SvgHomeFill />
             </BreadcrumbItem>

--- a/apps/web/app/[locale]/(with-layout)/search/components/search-reviews-section.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/components/search-reviews-section.tsx
@@ -51,7 +51,7 @@ function VideoReviewSection({
 
   return (
     <div className="flex max-w-[1366px] flex-col gap-[3.2rem] pt-[3.2rem]">
-      <p className="jp-head3 font-bold text-gray-700">動画レビュー</p>
+      <p className="head3 font-bold text-gray-700">動画レビュー</p>
       {isPending ? (
         <CardSkeletonWrapper type="REVIEW_VIDEO" />
       ) : !reviews || reviews.length === 0 ? (
@@ -114,7 +114,7 @@ function ImageReviewSection({
 
   return (
     <div className="flex max-w-[1366px] flex-col gap-[3.2rem] pt-[3.2rem]">
-      <p className="jp-head3 font-bold text-gray-700">写真付きレビュー</p>
+      <p className="head3 font-bold text-gray-700">写真付きレビュー</p>
       {isPending ? (
         <CardSkeletonWrapper type="REVIEW_IMAGE" />
       ) : !reviews || reviews.length === 0 ? (

--- a/apps/web/app/[locale]/(with-layout)/search/page.client.tsx
+++ b/apps/web/app/[locale]/(with-layout)/search/page.client.tsx
@@ -44,7 +44,7 @@ export default function SearchPageClient({
       />
       {validatedParams.keyword && (
         <div className="mx-auto w-[1366px] px-[11.9rem] py-[6rem]">
-          <p className="jp-head2 text-gray-800">
+          <p className="head2 text-gray-800">
             「
             <span className="inline-block max-w-[80rem] truncate align-bottom">
               {validatedParams.keyword}

--- a/apps/web/app/[locale]/review-modal/components/media/media-info.tsx
+++ b/apps/web/app/[locale]/review-modal/components/media/media-info.tsx
@@ -40,9 +40,9 @@ export default function MediaInfo({
       <div className="mt-auto flex flex-col">
         <div className="mb-[1.2rem] flex flex-row items-center gap-[1.2rem]">
           <Avatar src={user.avatarUrl ?? undefined} />
-          <p className="en-body1 font-bold text-white">{user.name}</p>
+          <p className="body1 font-bold text-white">{user.name}</p>
         </div>
-        <p className="en-caption1 text-white">{date}</p>
+        <p className="caption1 text-white">{date}</p>
       </div>
       <div className="flex flex-col items-center gap-4">
         <SvgSend className="h-[6.4rem] cursor-pointer fill-white transition-colors hover:fill-gray-400" />
@@ -59,7 +59,7 @@ export default function MediaInfo({
           className="text-white"
         >
           {isLiked ? <SvgGoodFill /> : <SvgGoodOutline />}
-          <span className="text-en-body1">{likeCount}</span>
+          <span className="body1">{likeCount}</span>
         </ReactionToggle>
       </div>
     </div>

--- a/apps/web/app/[locale]/review-modal/components/review/comment.tsx
+++ b/apps/web/app/[locale]/review-modal/components/review/comment.tsx
@@ -13,11 +13,11 @@ export default function Comment({ children, type }: CommentProps) {
         ) : (
           <SvgBad />
         )}
-        <span className="jp-body1 font-bold text-gray-600">
+        <span className="body1 font-bold text-gray-600">
           {type === 'positive' ? '良かったです' : '気になる点'}
         </span>
       </div>
-      <div className="jp-body2 text-gray-800">{children}</div>
+      <div className="body2 text-gray-800">{children}</div>
     </div>
   );
 }

--- a/apps/web/app/[locale]/review-modal/components/review/review-info.tsx
+++ b/apps/web/app/[locale]/review-modal/components/review/review-info.tsx
@@ -44,7 +44,7 @@ export default function ReviewInfo({
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden rounded-r-xl">
-      <header className="text-jp-body1 sticky top-0 z-10 flex h-[4.8rem] items-center justify-between border-b border-pink-500 bg-white pl-[1.6rem] font-bold">
+      <header className="body1 sticky top-0 z-10 flex h-[4.8rem] items-center justify-between border-b border-pink-500 bg-white pl-[1.6rem] font-bold">
         <span>レビュー</span>
         <IconButton
           icon={<SvgClose />}
@@ -56,7 +56,7 @@ export default function ReviewInfo({
 
       <div className="noMousewheel flex-1 overflow-y-scroll p-[1.6rem] pb-[11rem] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-400 [&::-webkit-scrollbar-track]:bg-gray-200 [&::-webkit-scrollbar]:w-2.5">
         <Star rating={rating} size="sm" color="yellow" />
-        <div className="text-jp-caption1 mt-[1.2rem] flex gap-[0.6rem] font-medium text-gray-600">
+        <div className="caption1 mt-[1.2rem] flex gap-[0.6rem] font-medium text-gray-600">
           <span className="flex-shrink-0">オプション :</span>
           <span className="line-clamp-2 flex-1">{productOption}</span>
         </div>
@@ -82,10 +82,10 @@ export default function ReviewInfo({
           className="mr-[1.2rem] flex cursor-pointer flex-col items-start gap-[0.4rem]"
           onClick={handleProductClick}
         >
-          <span className="jp-body1 truncate font-bold text-gray-800">
+          <span className="body1 truncate font-bold text-gray-800">
             {brandName}
           </span>
-          <span className="jp-body2 w-[23.3rem] truncate text-gray-800">
+          <span className="body2 w-[23.3rem] truncate text-gray-800">
             {productName}
           </span>
         </div>

--- a/apps/web/components/card/BracketChip.tsx
+++ b/apps/web/components/card/BracketChip.tsx
@@ -20,7 +20,7 @@ export default function BracketChip({
   return (
     <div
       className={cn(
-        'inter-body1 flex h-[3.2rem] w-[8.8rem] items-center justify-center text-white',
+        'body1 flex h-[3.2rem] w-[8.8rem] items-center justify-center text-white',
         CHIP_COLOR[chipVariant],
         className
       )}

--- a/apps/web/components/card/Card.tsx
+++ b/apps/web/components/card/Card.tsx
@@ -56,8 +56,8 @@ export default function Card({
       />
       <div className="absolute bottom-0 flex h-[11.5rem] w-full flex-col gap-[0.8rem] bg-white p-[1.6rem] transition-all duration-300 group-hover:h-[16.3rem]">
         <div>
-          <p className="inter-body4">{brand}</p>
-          <p className="inter-title3">{title}</p>
+          <p className="body4">{brand}</p>
+          <p className="title3">{title}</p>
         </div>
         <div className="flex items-center gap-[0.8rem]">
           <InfoChip text={label} />
@@ -69,7 +69,7 @@ export default function Card({
         <div className="mt-auto">
           <Link
             href={`/campaign/${campaignId}`}
-            className="inter-body2 h-[4.8rem] w-full rounded-[3.2rem] bg-pink-100 font-[700] text-pink-500 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+            className="body2 h-[4.8rem] w-full rounded-[3.2rem] bg-pink-100 font-[700] text-pink-500 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
           >
             {card('GoToApply')}
           </Link>

--- a/apps/web/components/card/card-product.tsx
+++ b/apps/web/components/card/card-product.tsx
@@ -53,7 +53,7 @@ export default function CardProduct({
         {ranking && <Badge rank={ranking} />}
       </div>
       <div className="flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-dashed border-pink-500">
-        <p className="jp-body1 font-[700]">{brandName}</p>
+        <p className="body1 font-[700]">{brandName}</p>
         <IconButton
           onClick={(e) => handleLikeClick(productId, e)}
           size="md"
@@ -70,11 +70,11 @@ export default function CardProduct({
         />
       </div>
       <div className="flex h-[4.4rem] items-center border-b-[0.1rem] border-dashed border-pink-500">
-        <p className="jp-body2 w-full truncate font-[500]" title={productName}>
+        <p className="body2 w-full truncate font-[500]" title={productName}>
           {productName}
         </p>
       </div>
-      <div className="en-caption1 flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-pink-500 text-gray-600">
+      <div className="caption1 flex h-[4.4rem] items-center justify-between border-b-[0.1rem] border-pink-500 text-gray-600">
         <p>{unit}</p>
         <div className="flex items-center">
           <SvgStar size={16} className="fill-yellow" />

--- a/apps/web/components/card/card-review.tsx
+++ b/apps/web/components/card/card-review.tsx
@@ -85,13 +85,13 @@ export default function CardReview({
         <div className="absolute bottom-0 left-0 right-0 flex flex-col gap-[1rem] bg-gradient-to-t from-black/60 to-transparent px-[1.6rem] py-[1.2rem]">
           <div className="flex-1">
             <p
-              className="en-title2 truncate font-bold text-white"
+              className="title2 truncate font-bold text-white"
               title={brandName}
             >
               {brandName}
             </p>
             <p
-              className="jp-body2 truncate font-medium text-white"
+              className="body2 truncate font-medium text-white"
               title={productName}
             >
               {productName}
@@ -99,7 +99,7 @@ export default function CardReview({
           </div>
           <div className="flex flex-shrink-0 items-center gap-[0.8rem]">
             <SvgGoodFill size={24} className="fill-white" />
-            <p className="en-body1 font-medium text-white">{likeCount}</p>
+            <p className="body1 font-medium text-white">{likeCount}</p>
           </div>
         </div>
       </div>

--- a/apps/web/components/footer/footer.tsx
+++ b/apps/web/components/footer/footer.tsx
@@ -92,8 +92,8 @@ function FooterLeft({ title, desc }: Pick<FooterProps, 'title' | 'desc'>) {
   return (
     <div className="flex flex-1 flex-col items-start gap-8 bg-pink-100 md:gap-12 lg:gap-[5.6rem]">
       <div className="flex w-full flex-col items-start gap-4 md:gap-6 lg:gap-[2.4rem]">
-        <p className="en-title3 font-bold leading-loose">{title}</p>
-        <p className="jp-body2 font-medium text-gray-600">{desc}</p>
+        <p className="title3 font-bold leading-loose">{title}</p>
+        <p className="body2 font-medium text-gray-600">{desc}</p>
       </div>
       <div className="flex items-center gap-2 md:gap-[0.8rem]">
         <Link
@@ -128,7 +128,7 @@ function FooterLeft({ title, desc }: Pick<FooterProps, 'title' | 'desc'>) {
 function FooterBottom({ copyright }: Pick<FooterProps, 'copyright'>) {
   return (
     <div className="flex min-h-[5.2rem] w-full items-center justify-center gap-4 border-t border-dashed border-pink-500 bg-pink-100 px-4 py-4">
-      <p className="en-body1 bg-pink-100 text-center font-medium text-pink-500">
+      <p className="body1 bg-pink-100 text-center font-medium text-pink-500">
         {copyright}
       </p>
     </div>
@@ -143,7 +143,7 @@ function FooterRight({ menu }: Pick<FooterProps, 'menu'>) {
           key={title}
           className="flex min-w-0 flex-1 flex-col items-start gap-4 md:gap-6 lg:w-[16.8rem] lg:gap-[2.4rem]"
         >
-          <p className="jp-body1 font-bold">{title}</p>
+          <p className="body1 font-bold">{title}</p>
           <div className="flex w-full flex-col items-start justify-start gap-2 md:gap-[0.8rem]">
             {option.map((item) =>
               item.href ? (
@@ -152,7 +152,7 @@ function FooterRight({ menu }: Pick<FooterProps, 'menu'>) {
                   key={item.name}
                   className="flex h-[3.2rem] w-full items-center gap-2 py-[1rem] md:gap-[0.8rem]"
                 >
-                  <p className="jp-body2 whitespace-nowrap font-medium">
+                  <p className="body2 whitespace-nowrap font-medium">
                     {item.name}
                   </p>
                   <SvgArrowRight />
@@ -162,7 +162,7 @@ function FooterRight({ menu }: Pick<FooterProps, 'menu'>) {
                   key={item.name}
                   className="flex h-[3.2rem] w-full cursor-default items-center gap-2 py-[1rem] md:gap-[0.8rem]"
                 >
-                  <p className="jp-body2 cursor-not-allowed whitespace-nowrap font-medium">
+                  <p className="body2 cursor-not-allowed whitespace-nowrap font-medium">
                     {item.name}
                   </p>
                   <SvgArrowRight className="text-gray-400" />

--- a/apps/web/components/forms/FormSection.tsx
+++ b/apps/web/components/forms/FormSection.tsx
@@ -14,8 +14,8 @@ export function FormSection({
   return (
     <div className="space-y-[1.6rem]">
       <div>
-        <h2 className="kr-title2 font-bold text-gray-800">{title}</h2>
-        <p className="kr-body4 mt-[0.4rem] text-gray-500">{description}</p>
+        <h2 className="title2 font-bold text-gray-800">{title}</h2>
+        <p className="body4 mt-[0.4rem] text-gray-500">{description}</p>
       </div>
       <div className="space-y-4">{children}</div>
     </div>

--- a/apps/web/components/forms/PhoneFormField.tsx
+++ b/apps/web/components/forms/PhoneFormField.tsx
@@ -43,7 +43,7 @@ export function PhoneFormField({
 
   return (
     <div className={cn('flex items-center justify-between', className)}>
-      <label className="kr-body1 flex items-center font-bold text-gray-700">
+      <label className="body1 flex items-center font-bold text-gray-700">
         {required && (
           <span className="mr-[0.8rem] h-[0.6rem] w-[0.6rem] rounded-full bg-[#EF4351]" />
         )}

--- a/apps/web/components/forms/SignupFormLayout.tsx
+++ b/apps/web/components/forms/SignupFormLayout.tsx
@@ -24,7 +24,7 @@ export function SignupFormLayout({
   return (
     <main className="bg-gray-100 py-[6.4rem]">
       <div className="mx-auto max-w-[74.4rem] px-4">
-        <h1 className="inter-head2 mb-[2.2rem] text-center font-bold text-pink-500">
+        <h1 className="head2 mb-[2.2rem] text-center font-bold text-pink-500">
           {title}
         </h1>
 

--- a/apps/web/components/forms/TextFormField.tsx
+++ b/apps/web/components/forms/TextFormField.tsx
@@ -29,7 +29,7 @@ export function TextFormField({
 }: TextFormFieldProps) {
   return (
     <div className={cn('flex items-center justify-between', className)}>
-      <label className="kr-body1 flex items-center font-bold text-gray-700">
+      <label className="body1 flex items-center font-bold text-gray-700">
         {required && (
           <span className="mr-[0.8rem] h-[0.6rem] w-[0.6rem] rounded-full bg-[#EF4351]" />
         )}

--- a/apps/web/components/gnb/gnb-auth.tsx
+++ b/apps/web/components/gnb/gnb-auth.tsx
@@ -29,7 +29,7 @@ export default function GnbAuth() {
 
           <DropdownMenuContent
             align="end"
-            className="inter-body4 mt-[0.4rem] w-[var(--radix-dropdown-menu-trigger-width)] font-[500]"
+            className="body4 mt-[0.4rem] w-[var(--radix-dropdown-menu-trigger-width)] font-[500]"
           >
             <DropdownMenuItem>{t('myPage')}</DropdownMenuItem>
             <DropdownMenuItem>{t('logOut')}</DropdownMenuItem>

--- a/apps/web/components/gnb/gnb-language.tsx
+++ b/apps/web/components/gnb/gnb-language.tsx
@@ -37,10 +37,7 @@ export default function GnbLanguage() {
           <SvgLanguage size={32} className="h-full w-full" />
         </SelectTrigger>
 
-        <SelectContent
-          className="inter-body4 mt-[2rem] w-[8.4rem]"
-          align="center"
-        >
+        <SelectContent className="body4 mt-[2rem] w-[8.4rem]" align="center">
           {LANGUAGES.map((lang) => (
             <SelectItem
               key={lang.value}

--- a/apps/web/components/gnb/gnb.tsx
+++ b/apps/web/components/gnb/gnb.tsx
@@ -6,7 +6,7 @@ import GnbMenu from './gnb-menu';
 
 export default function Gnb() {
   return (
-    <header className="inter-body1 flex h-[7.2rem] w-full items-center justify-between px-[11.9rem] font-[700]">
+    <header className="body1 flex h-[7.2rem] w-full items-center justify-between px-[11.9rem] font-[700]">
       <Image src="/images/logo.png" alt="logo" width={162} height={27} />
       <GnbMenu />
       <div className="flex h-full items-center gap-[1.6rem]">

--- a/apps/web/components/header/category-option-bar.tsx
+++ b/apps/web/components/header/category-option-bar.tsx
@@ -37,7 +37,7 @@ export function CategoryOptionBar({
                 <Link
                   href={getUrl('', selectedCategoryKey, option, 'PRODUCT')}
                   className={cn(
-                    'jp-body2 cursor-pointer whitespace-nowrap px-[2.4rem] py-[1rem] hover:text-pink-500',
+                    'body2 cursor-pointer whitespace-nowrap px-[2.4rem] py-[1rem] hover:text-pink-500',
                     isActive ? 'font-bold text-pink-500' : 'text-gray-600'
                   )}
                   onClick={() => handleSelectOption(option)}

--- a/apps/web/components/header/category-section.tsx
+++ b/apps/web/components/header/category-section.tsx
@@ -55,7 +55,7 @@ export function CategorySection({
               href={getUrl('', key, 'ALL', 'PRODUCT')}
               key={key}
               className={cn(
-                'jp-title2 flex h-[6rem] cursor-pointer items-center whitespace-nowrap px-[3.2rem] pb-[1rem] pt-[1rem] font-bold',
+                'title2 flex h-[6rem] cursor-pointer items-center whitespace-nowrap px-[3.2rem] pb-[1rem] pt-[1rem] font-bold',
                 isActive ? 'text-pink-500' : 'text-gray-800'
               )}
               onMouseEnter={() => handleSelectCategory(key)}

--- a/apps/web/components/header/search-bar.tsx
+++ b/apps/web/components/header/search-bar.tsx
@@ -38,7 +38,7 @@ export function SearchBar({
             onChange={(e) => handleChangeSearchValue(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="ラネージュ"
-            className="jp-title2 h-[5.2rem] w-full text-right font-bold leading-[3rem] text-gray-800"
+            className="title2 h-[5.2rem] w-full text-right font-bold leading-[3rem] text-gray-800"
           />
           <div className="flex h-[6.4rem] w-[5.2rem] shrink-0 cursor-pointer items-center justify-center p-[1.4rem]">
             {searchValue.trim() ? (

--- a/apps/web/components/header/top-util.tsx
+++ b/apps/web/components/header/top-util.tsx
@@ -35,7 +35,7 @@ function TopUtilItem({
       disabled={disabled}
     >
       {icon}
-      <p className="jp-body2 text-gray-600">{label}</p>
+      <p className="body2 text-gray-600">{label}</p>
     </button>
   );
 }

--- a/apps/web/components/input/content-with-label.tsx
+++ b/apps/web/components/input/content-with-label.tsx
@@ -24,7 +24,7 @@ export default function ContentWithLabel({
       {...props}
     >
       <label
-        className={cn('jp-title2 font-bold text-gray-800', labelClassName)}
+        className={cn('title2 font-bold text-gray-800', labelClassName)}
         htmlFor={htmlFor}
       >
         {required && <span className="text-pink-500">*</span>}

--- a/packages/design-system/src/components/badge/Badge.tsx
+++ b/packages/design-system/src/components/badge/Badge.tsx
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority';
+
 import { cn } from '../../lib/utils';
 
 interface BadgeProps {
@@ -9,7 +10,7 @@ interface BadgeProps {
 const OTHER_RANK_STYLE = `border-b-[0.1rem] border-r-[0.1rem] border-pink-500 bg-pink-100 text-pink-500`;
 
 const badgeVariants = cva(
-  `en-title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 absolute`,
+  `title2 flex h-[3.6rem] w-[3.6rem] items-center justify-center font-[700] absolute left-0 top-0 absolute`,
   {
     variants: {
       variant: {

--- a/packages/design-system/src/components/breadcrumb/Breadcrumb.tsx
+++ b/packages/design-system/src/components/breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,8 @@
+import * as React from 'react';
+
 import { Slot } from '@radix-ui/react-slot';
 import { ChevronRight, MoreHorizontal } from 'lucide-react';
-import * as React from 'react';
+
 import { cn } from '../../lib/utils';
 
 function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
@@ -12,7 +14,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'jp-body2 flex flex-wrap items-center gap-1.5 break-words sm:gap-2.5',
+        'body2 flex flex-wrap items-center gap-1.5 break-words sm:gap-2.5',
         className
       )}
       {...props}

--- a/packages/design-system/src/components/button/Button.tsx
+++ b/packages/design-system/src/components/button/Button.tsx
@@ -44,10 +44,10 @@ const buttonVariants = cva(
         md: 'rounded-[3.2rem]',
       },
       fontType: {
-        InterTitle3: 'inter-title3',
-        InterBody1: 'inter-body1',
-        InterBody2: 'inter-body2',
-        InterBody4: 'inter-body4',
+        InterTitle3: 'title3',
+        InterBody1: 'body1',
+        InterBody2: 'body2',
+        InterBody4: 'body4',
       },
     },
     compoundVariants: [

--- a/packages/design-system/src/components/error-notice/ErrorNotice.tsx
+++ b/packages/design-system/src/components/error-notice/ErrorNotice.tsx
@@ -15,7 +15,7 @@ export default function ErrorNotice({
   return (
     <p
       className={cn(
-        'inter-caption3 mt-[0.2rem] flex h-[1.9rem] items-center gap-[0.8rem] font-[400] text-[color:var(--color-red)]',
+        'caption3 mt-[0.2rem] flex h-[1.9rem] items-center gap-[0.8rem] font-[400] text-[color:var(--color-red)]',
         className
       )}
     >

--- a/packages/design-system/src/components/info-chip/InfoChip.tsx
+++ b/packages/design-system/src/components/info-chip/InfoChip.tsx
@@ -20,8 +20,8 @@ const infoChipVariants = cva('inline-flex items-center gap-[0.5rem] border', {
       blue: 'border-blue text-blue',
     },
     size: {
-      md: 'rounded-[1.6rem] px-2 py-1 inter-caption1',
-      lg: 'rounded-[2.4rem] py-[0.6rem] px-[1.6rem] inter-body1',
+      md: 'rounded-[1.6rem] px-2 py-1 caption1',
+      lg: 'rounded-[2.4rem] py-[0.6rem] px-[1.6rem] body1',
     },
   },
 });

--- a/packages/design-system/src/components/input-field/Input.tsx
+++ b/packages/design-system/src/components/input-field/Input.tsx
@@ -10,11 +10,12 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   handleRightIconClick?: () => void;
 }
 
+// TODO Input Variation 수정 필요
 const inputVariants = cva('w-full focus:outline-none', {
   variants: {
     fontType: {
-      Inter: 'inter-body3',
-      NotoSansKR: 'kr-body3',
+      Inter: 'body3',
+      NotoSansKR: 'body3',
     },
   },
   defaultVariants: {

--- a/packages/design-system/src/components/input/Input.tsx
+++ b/packages/design-system/src/components/input/Input.tsx
@@ -1,5 +1,7 @@
-import { cva } from 'class-variance-authority';
 import * as React from 'react';
+
+import { cva } from 'class-variance-authority';
+
 import { cn } from '../../lib/utils';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -10,8 +12,8 @@ const inputVariants = cva('w-[40.8rem] focus:outline-none', {
   variants: {
     type: {
       default:
-        'h-[5.2rem] border-b border-b-gray-400 jp-body2 hover:border-b-pink-500 focus:border-b-pink-500',
-      search: 'h-[6.4rem] text-right jp-title1 font-bold focus:bg-gray-50',
+        'h-[5.2rem] border-b border-b-gray-400 body2 hover:border-b-pink-500 focus:border-b-pink-500',
+      search: 'h-[6.4rem] text-right title1 font-bold focus:bg-gray-50',
     },
   },
   defaultVariants: {

--- a/packages/design-system/src/components/modal-button/ModalButton.tsx
+++ b/packages/design-system/src/components/modal-button/ModalButton.tsx
@@ -23,7 +23,7 @@ export default function ModalButton({
       <button
         type="button"
         className={cn(
-          'inter-body1 flex h-[5.6rem] w-[55rem] items-center justify-center rounded-b-[3.2rem] bg-pink-100 px-[3.2rem] py-[1.6rem] text-pink-500 hover:bg-pink-200',
+          'body1 flex h-[5.6rem] w-[55rem] items-center justify-center rounded-b-[3.2rem] bg-pink-100 px-[3.2rem] py-[1.6rem] text-pink-500 hover:bg-pink-200',
           isSelected && 'bg-pink-500'
         )}
         onClick={props.onClick}
@@ -38,7 +38,7 @@ export default function ModalButton({
     return (
       <button
         className={cn(
-          'inter-body1 flex h-[5.6rem] w-[27.5rem] items-center justify-center bg-white px-[3.2rem] py-[1rem] text-gray-600 hover:bg-pink-100',
+          'body1 flex h-[5.6rem] w-[27.5rem] items-center justify-center bg-white px-[3.2rem] py-[1rem] text-gray-600 hover:bg-pink-100',
           isSelected && 'bg-pink-100'
         )}
         style={{ borderBottomLeftRadius: '3.2rem' }}
@@ -54,7 +54,7 @@ export default function ModalButton({
     return (
       <button
         className={cn(
-          'inter-body1 flex h-[5.6rem] w-[27.5rem] items-center justify-center bg-pink-100 px-[3.2rem] py-[1rem] text-pink-500 hover:bg-pink-200',
+          'body1 flex h-[5.6rem] w-[27.5rem] items-center justify-center bg-pink-100 px-[3.2rem] py-[1rem] text-pink-500 hover:bg-pink-200',
           isSelected && 'bg-pink-200'
         )}
         style={{ borderBottomRightRadius: '3.2rem' }}

--- a/packages/design-system/src/components/modal-header/ModalHeader.tsx
+++ b/packages/design-system/src/components/modal-header/ModalHeader.tsx
@@ -19,7 +19,7 @@ export default function ModalHeader({
       )}
       {...props}
     >
-      <div className="inter-title2 text-pink-500">{text}</div>
+      <div className="title2 text-pink-500">{text}</div>
       {rightContent && (
         <div className="absolute right-[1.6rem] top-[1.6rem] cursor-pointer">
           {rightContent}

--- a/packages/design-system/src/components/pagenation/Pagenation.tsx
+++ b/packages/design-system/src/components/pagenation/Pagenation.tsx
@@ -28,7 +28,7 @@ export function PageButton({
       type="button"
       onClick={() => handlePageChange(page)}
       className={cn(
-        'inter-title2 flex h-[3.2rem] w-[3.2rem] items-center justify-center',
+        'title2 flex h-[3.2rem] w-[3.2rem] items-center justify-center',
         isActive ? 'text-pink-500' : 'text-gray-400 hover:text-gray-600'
       )}
     >

--- a/packages/design-system/src/components/select/Select.tsx
+++ b/packages/design-system/src/components/select/Select.tsx
@@ -162,7 +162,7 @@ export function Select({
             <SelectItem key={option.label} value={option.label}>
               <div className="flex items-center gap-[16px]">
                 {option.icon}
-                <span className="inter-body4 font-[500] text-gray-800">
+                <span className="body4 font-[500] text-gray-800">
                   {option.label}
                 </span>
               </div>

--- a/packages/design-system/src/components/tab/Tab.tsx
+++ b/packages/design-system/src/components/tab/Tab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ReactNode } from 'react';
 
 import { cn } from '../../lib/utils';

--- a/packages/design-system/src/components/tag/Tag.tsx
+++ b/packages/design-system/src/components/tag/Tag.tsx
@@ -10,7 +10,7 @@ export default function Tag({ text, className }: TagProps) {
   return (
     <div
       className={cn(
-        'jp-caption1 inline-flex w-fit items-center justify-center gap-[0.4rem] rounded-[0.4rem] bg-gray-100 px-[0.8rem] py-[0.45rem] font-[500] text-gray-800',
+        'caption1 inline-flex w-fit items-center justify-center gap-[0.4rem] rounded-[0.4rem] bg-gray-100 px-[0.8rem] py-[0.45rem] font-[500] text-gray-800',
         className
       )}
     >

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -124,261 +124,104 @@
 }
 
 @layer utilities {
-  /* 커스텀 유틸리티 클래스 */
-  .jp-head1 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-head1);
-    line-height: 140%;
+  html[lang='ko'] {
+    --font-primary: var(--font-noto-sans-kr);
+    --text-head1: var(--text-noto-sans-kr-head1);
+    --text-head2: var(--text-noto-sans-kr-head2);
+    --text-head3: var(--text-noto-sans-kr-head3);
+    --text-title1: var(--text-noto-sans-kr-title1);
+    --text-title2: var(--text-noto-sans-kr-title2);
+    --text-title3: var(--text-noto-sans-kr-title3);
+    --text-body1: var(--text-noto-sans-kr-body1);
+    --text-body2: var(--text-noto-sans-kr-body2);
+    --text-body3: var(--text-noto-sans-kr-body3);
+    --text-body4: var(--text-noto-sans-kr-body4);
+    --text-caption: var(--text-noto-sans-kr-caption);
   }
-  .jp-head2 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-head2);
-    line-height: 140%;
+
+  html:not([lang='ko']) {
+    --font-primary: var(--font-inter);
+    --text-head1: var(--text-inter-head1);
+    --text-head2: var(--text-inter-head2);
+    --text-head3: var(--text-inter-head3);
+    --text-title1: var(--text-inter-title1);
+    --text-title2: var(--text-inter-title2);
+    --text-title3: var(--text-inter-title3);
+    --text-body1: var(--text-inter-body1);
+    --text-body2: var(--text-inter-body2);
+    --text-body3: var(--text-inter-body3);
+    --text-body4: var(--text-inter-body4);
+    --text-caption: var(--text-inter-caption);
   }
-  .jp-head3 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-head3);
+
+  /* 타이포그래피 클래스 - 한 번만 정의 */
+  .head1 {
+    font-family: var(--font-primary);
+    font-size: var(--text-head1);
+    line-height: 150%;
+  }
+  .head2 {
+    font-family: var(--font-primary);
+    font-size: var(--text-head2);
+    line-height: 150%;
+  }
+  .head3 {
+    font-family: var(--font-primary);
+    font-size: var(--text-head3);
     line-height: 150%;
   }
 
-  /* JP Title */
-  .jp-title1 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-title1);
+  .title1 {
+    font-family: var(--font-primary);
+    font-size: var(--text-title1);
     line-height: 150%;
   }
-  .jp-title2 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-title2);
+  .title2 {
+    font-family: var(--font-primary);
+    font-size: var(--text-title2);
     line-height: 150%;
   }
-  .jp-title3 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-title3);
-    line-height: 150%;
-  }
-
-  /* JP Body */
-  .jp-body1 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-body1);
-    line-height: 160%;
-  }
-  .jp-body2 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-body2);
-    line-height: 160%;
-  }
-
-  /* JP Caption */
-  .jp-caption1 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-caption1);
-    line-height: 160%;
-  }
-  .jp-caption2 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-caption2);
-    line-height: 160%;
-  }
-  .jp-caption3 {
-    font-family: var(--font-noto-sans-jp);
-    font-size: var(--text-jp-caption3);
-    line-height: 160%;
-  }
-
-  /* EN Heading */
-  .en-head1 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-head1);
-    line-height: 150%;
-  }
-  .en-head2 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-head2);
+  .title3 {
+    font-family: var(--font-primary);
+    font-size: var(--text-title3);
     line-height: 150%;
   }
 
-  /* EN Title */
-  .en-title1 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-title1);
+  .body1 {
+    font-family: var(--font-primary);
+    font-size: var(--text-body1);
     line-height: 150%;
   }
-  .en-title2 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-title2);
+  .body2 {
+    font-family: var(--font-primary);
+    font-size: var(--text-body2);
     line-height: 150%;
   }
-  .en-title3 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-title3);
+  .body3 {
+    font-family: var(--font-primary);
+    font-size: var(--text-body3);
     line-height: 150%;
   }
-
-  /* EN Body */
-  .en-body1 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-body1);
-    line-height: 100%;
-  }
-  .en-body2 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-body2);
-    line-height: 100%;
-  }
-
-  /* EN Caption */
-  .en-caption1 {
-    font-family: var(--font-pretendard);
-    font-size: var(--text-en-caption1);
+  .body4 {
+    font-family: var(--font-primary);
+    font-size: var(--text-body4);
     line-height: 150%;
   }
 
-  /*Inter head*/
-  .inter-head1 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-head1);
-    line-height: 140%;
-  }
-  .inter-head2 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-head2);
-    line-height: 140%;
-  }
-  .inter-head3 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-head3);
-    line-height: 140%;
-  }
-
-  /*Inter title*/
-  .inter-title1 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-title1);
-    line-height: 150%;
-  }
-  .inter-title2 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-title2);
-    line-height: 150%;
-  }
-  .inter-title3 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-title3);
-    line-height: 150%;
-  }
-
-  /*Inter body*/
-  .inter-body1 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-body1);
-    line-height: 150%;
-  }
-  .inter-body2 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-body2);
-    line-height: 150%;
-  }
-  .inter-body3 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-body3);
-    line-height: 150%;
-  }
-  .inter-body4 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-body4);
-    line-height: 150%;
-  }
-
-  /*Inter caption*/
-  .inter-caption1 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-caption);
-    line-height: 160%;
-  }
-  .inter-caption2 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-caption);
-    line-height: 160%;
-  }
-  .inter-caption3 {
-    font-family: var(--font-inter);
-    font-size: var(--text-inter-caption);
+  .caption,
+  .caption1,
+  .caption2,
+  .caption3 {
+    font-family: var(--font-primary);
+    font-size: var(--text-caption);
     line-height: 160%;
   }
 
-  /*Noto Sans KR head*/
-  .kr-head1 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-head1);
-    line-height: 150%;
-  }
-  .kr-head2 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-head2);
-    line-height: 150%;
-  }
-  .kr-head3 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-head3);
-    line-height: 150%;
-  }
-
-  /*Noto Sans KR title*/
-  .kr-title1 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-title1);
-    line-height: 150%;
-  }
-  .kr-title2 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-title2);
-    line-height: 150%;
-  }
-  .kr-title3 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-title3);
-    line-height: 150%;
-  }
-
-  /*Noto Sans KR body*/
-  .kr-body1 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-body1);
-    line-height: 150%;
-  }
-  .kr-body2 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-body2);
-    line-height: 150%;
-  }
-  .kr-body3 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-body3);
-    line-height: 150%;
-  }
-  .kr-body4 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-body4);
-    line-height: 150%;
-  }
-
-  /*Noto Sans KR caption*/
-  .kr-caption1 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-caption);
-    line-height: 160%;
-  }
-  .kr-caption2 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-caption);
-    line-height: 160%;
-  }
-  .kr-caption3 {
-    font-family: var(--font-noto-sans-kr);
-    font-size: var(--text-noto-sans-kr-caption);
-    line-height: 160%;
+  /* line-height 조정이 필요한 경우 */
+  html:not([lang='ko']) .head1,
+  html:not([lang='ko']) .head2,
+  html:not([lang='ko']) .head3 {
+    line-height: 140%; /* Inter는 head에서 140% */
   }
 
   .shadow-button {


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #340 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->
기존에는 정해진 텍스트 내용에 따라 영어, 숫자, 일본어에 따라 정적으로 스타일을 주입하면 됐지만
이번에 다국어를 도입하면서
<img width="819" height="235" alt="image" src="https://github.com/user-attachments/assets/2c0aba65-0e6f-4206-a8a5-ee3132fdf8aa" />
유저가 선택한 언어에 따라 동적인 폰트 스타일을 적용할 필요가 생겼습니다. 하지만 기존에 `shared-style.css`에 정의된 스타일대로면 매번 locale에서 ko인지, en인지, esn인지 파악하고 이에 따라 조건부로 className에 적용해줘야했습니다. 이러한 방식은 매우매우 귀찮고 실수를 불러올 수도 있기 때문에 head1, title2, body1 이런식으로 키워드만 입력하면 html의 lang 속성에서 locale을 불러와 자동으로 언어별 폰트를 지정해주도록 하였습니다.

- 같은 title1, head1, body2더라도 폰트에 따라 fontSize가 다른 경우가 대부분인데, 이 경우까지 커버하기 위해 CSS 변수 기반으로 각 케이스를 정의했습니다.

* 번외(직접적인 이유는 아님)
(https://tailwindcss.com/docs/detecting-classes-in-source-files 를 보면 tailwind에서 동적 스타일링을 반대하는 것은 아니지만 `<div className={`text-${color}-600`} />` , `<div class="text-{{ error ? 'red' : 'green' }}-600" />
` 이런식으로 "조합"을 동적으로 하거나 문자열이 코드에 완전히 의존하지 않는 경우를 권장하지 않는데 조건부로 className에 적용할 시에 이런 실수가 생길 수도 있겠다고 생각했음)

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [X] `shared-style.css`에서 locale 기반 폰트 적용하기
- [X] body, title, caption, head 등 키워드에 따른 기타 스타일 적용

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
input 컴포넌트 보니까 폰트를 props로 받는 것 같던데 해당 PR 적용되면 필요 없을 것 같아서 props 없애도 될 것 같습니다 어느 브랜치에서 수정할까요?
