### PR TITLE
Feat(web): Table 컴포넌트 제작

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/page.tsx
+++ b/apps/web/app/[locale]/(with-layout)/page.tsx
@@ -1,5 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
+import Test from 'components/table/test';
+
 import HomeBanner from './(home)/components/home-banner';
 import HomeSection from './(home)/components/home-section';
 import HomeSectionCampaign from './(home)/components/home-section-campaign';
@@ -20,6 +22,7 @@ export default async function Main() {
           <HomeSectionCampaign kindOfCard="openingSoon" seeMore={false} />
         </HomeSection>
       </div>
+      <Test />
     </div>
   );
 }

--- a/apps/web/components/table/table-body.tsx
+++ b/apps/web/components/table/table-body.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+interface TableBodyProps {
+  data: ReactNode[][];
+  widths: string[];
+}
+
+export default function TableBody({ data, widths }: TableBodyProps) {
+  return (
+    <tbody>
+      {data.map((row, index) => (
+        <tr
+          key={index}
+          className="flex w-[93.6rem] items-center justify-end gap-[1.6rem] border-b border-gray-400 px-[1.6rem] py-[2.4rem]"
+        >
+          {row.map((cell, cellIndex) => (
+            <td
+              key={cellIndex}
+              className={`${widths[cellIndex]} flex justify-start`}
+            >
+              {cell}
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  );
+}

--- a/apps/web/components/table/table-header.tsx
+++ b/apps/web/components/table/table-header.tsx
@@ -1,0 +1,25 @@
+interface TableHeader {
+  label: string;
+  width: string;
+}
+
+interface TableHeaderProps {
+  headers: TableHeader[];
+}
+
+export default function TableHeader({ headers }: TableHeaderProps) {
+  return (
+    <thead>
+      <tr className="flex h-[3.5rem] w-[93.6rem] items-center justify-end gap-[1.6rem] border-b border-gray-400 px-[1.6rem]">
+        {headers.map((header, index) => (
+          <th
+            key={index}
+            className={`${header.width} caption1 flex justify-start font-[700] text-gray-600`}
+          >
+            {header.label}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+}

--- a/apps/web/components/table/table.tsx
+++ b/apps/web/components/table/table.tsx
@@ -1,0 +1,26 @@
+// Table.tsx - 수정된 버전
+import { ReactNode } from 'react';
+
+import TableBody from './table-body';
+import TableHeader from './table-header';
+
+interface TableHeader {
+  label: string;
+  width: string;
+}
+
+interface TableProps {
+  headers: TableHeader[];
+  data: ReactNode[][];
+}
+
+export default function Table({ headers, data }: TableProps) {
+  const widths = headers.map((h) => h.width);
+
+  return (
+    <table>
+      <TableHeader headers={headers} />
+      <TableBody data={data} widths={widths} />
+    </table>
+  );
+}

--- a/apps/web/components/table/test.tsx
+++ b/apps/web/components/table/test.tsx
@@ -9,28 +9,22 @@ export default function Test() {
 
   const tableData = [
     [
-      <div className="flex items-center gap-[0.8rem]">
-        <img
-          src="/profile1.jpg"
-          alt="profile"
-          className="h-8 w-8 rounded-full"
-        />
+      <div key="profile-1" className="flex items-center gap-[0.8rem]">
         <span>Mia Rodriguez</span>
       </div>,
-      <span>34.2K</span>,
-      <span className="rounded bg-green-100 px-2 py-1">승인</span>,
+      <span key="followers-1">34.2K</span>,
+      <span key="status-1" className="rounded bg-green-100 px-2 py-1">
+        승인
+      </span>,
     ],
     [
-      <div className="flex items-center gap-[0.8rem]">
-        <img
-          src="/profile2.jpg"
-          alt="profile"
-          className="h-8 w-8 rounded-full"
-        />
+      <div key="profile-2" className="flex items-center gap-[0.8rem]">
         <span>Alex Thompson</span>
       </div>,
-      <span>128.5K</span>,
-      <span className="rounded bg-yellow-100 px-2 py-1">대기중</span>,
+      <span key="followers-2">128.5K</span>,
+      <span key="status-2" className="rounded bg-yellow-100 px-2 py-1">
+        대기중
+      </span>,
     ],
   ];
 

--- a/apps/web/components/table/test.tsx
+++ b/apps/web/components/table/test.tsx
@@ -1,0 +1,38 @@
+import Table from './table';
+
+export default function Test() {
+  const headers = [
+    { label: '크리에이터', width: 'w-[20rem]' },
+    { label: '팔로워 수', width: 'w-[15rem]' },
+    { label: '상태', width: 'w-[10rem]' },
+  ];
+
+  const tableData = [
+    [
+      <div className="flex items-center gap-[0.8rem]">
+        <img
+          src="/profile1.jpg"
+          alt="profile"
+          className="h-8 w-8 rounded-full"
+        />
+        <span>Mia Rodriguez</span>
+      </div>,
+      <span>34.2K</span>,
+      <span className="rounded bg-green-100 px-2 py-1">승인</span>,
+    ],
+    [
+      <div className="flex items-center gap-[0.8rem]">
+        <img
+          src="/profile2.jpg"
+          alt="profile"
+          className="h-8 w-8 rounded-full"
+        />
+        <span>Alex Thompson</span>
+      </div>,
+      <span>128.5K</span>,
+      <span className="rounded bg-yellow-100 px-2 py-1">대기중</span>,
+    ],
+  ];
+
+  return <Table headers={headers} data={tableData} />;
+}


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #355 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] 테이블 컴포넌트 만들기
- [ ] 테스트용 코드 삭제

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
props로 ReactNode를 전달하는 방식이라
<img width="497" height="82" alt="image" src="https://github.com/user-attachments/assets/46a99c47-721b-4d92-b426-a53676237acd" />
- grid를 사용해서 head와 body의 열 너비를 자동으로 맞추는 방식으로 제작할까 고민했지만 현재 디자인 시스템에서 보여줄 head의 내용에 따라 픽셀 퍼펙트한 디자인 스펙 구현이 목적이기 때문에 너비를 주입하는 방식으로 제작하였습니다
- 사진의 테이블처럼 <td>에 화살표 버튼이 필요하다면 props로 ReactNode를 넣을 때 함께 넣어서 사용하면 될 것 같습니다(header에는 피그마에 나와있는 대로만 width 넣으면 됩니다!)

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->
<img width="937" height="180" alt="image" src="https://github.com/user-attachments/assets/02fae3c2-034c-4640-b65c-b1cbfa84a72d" />
