### PR TITLE
Feat(web): 메인 페이지 API 연동

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
@@ -1,11 +1,11 @@
 import { apiRequest } from 'app/api/apiRequest';
-import { CategoryValue } from 'types/category';
+import { CategoryKey } from 'types/category';
 
 import { CampaignApiResponse } from '../components/home-section-campaign';
 
 interface GetCampaignProps {
   section: 'KBeauty' | 'openingSoon';
-  category: CategoryValue;
+  category: CategoryKey;
   page: number;
   size: number;
   locale: string;

--- a/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
@@ -1,6 +1,8 @@
 import { apiRequest } from 'app/api/apiRequest';
 import { CategoryValue } from 'types/category';
 
+import { CampaignApiResponse } from '../components/home-section-campaign';
+
 interface GetCampaignProps {
   section: 'KBeauty' | 'openingSoon';
   category: CategoryValue;
@@ -15,13 +17,12 @@ export const getCampaignsByCategory = async ({
   page,
   size,
   locale,
-}: GetCampaignProps) => {
+}: GetCampaignProps): Promise<CampaignApiResponse> => {
   const langParam = locale.toUpperCase();
 
-  const response = await apiRequest({
+  const response = await apiRequest<CampaignApiResponse>({
     endPoint: `/api/campaigns${section === 'openingSoon' ? '/upcoming' : ''}?lang=${langParam}&category=${category}&page=${page}&size=${size}`,
     method: 'GET',
   });
-
   return response;
 };

--- a/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
@@ -1,0 +1,26 @@
+import { apiRequest } from 'app/api/apiRequest';
+import { CategoryValue } from 'types/category';
+
+interface GetCampaignProps {
+  section: 'KBeauty' | 'openingSoon';
+  category: CategoryValue;
+  page: number;
+  size: number;
+  locale: string;
+}
+
+export const getProductsByCategory = async ({
+  section,
+  category,
+  page,
+  size,
+  locale,
+}: GetCampaignProps) => {
+  const langParam = locale.toUpperCase();
+
+  const response = await apiRequest({
+    endPoint: `/api/campaigns${section === 'openingSoon' ? '/upcoming' : ''}?lang=${langParam}&category=${category}&page=${page}&size=${size}`,
+    method: 'GET',
+  });
+  return response;
+};

--- a/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/apis/index.ts
@@ -9,7 +9,7 @@ interface GetCampaignProps {
   locale: string;
 }
 
-export const getProductsByCategory = async ({
+export const getCampaignsByCategory = async ({
   section,
   category,
   page,
@@ -22,5 +22,6 @@ export const getProductsByCategory = async ({
     endPoint: `/api/campaigns${section === 'openingSoon' ? '/upcoming' : ''}?lang=${langParam}&category=${category}&page=${page}&size=${size}`,
     method: 'GET',
   });
+
   return response;
 };

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -1,63 +1,26 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 
-import { useParams } from 'next/navigation';
-
-import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { useRouter } from 'i18n/navigation';
-import { LanguageKey } from 'types/language';
 
 import { Pagenation } from '@lococo/design-system/pagenation';
 
-import { CategoryKey } from '../../../../../types/category';
-import { getCampaignsByCategory } from '../apis';
-import { campaignKeys } from '../query';
-import { CampaignApiResponse } from './home-section-campaign';
+import { useCampaignsPaginated } from '../hooks/useCampain';
 
 export default function CampaignAll() {
-  const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
-  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
-
-  const router = useRouter();
-  const params = useParams();
-  const pageParam = Array.isArray(params.page) ? params.page[0] : params.page;
-
-  const currentPage = pageParam ? parseInt(pageParam) : 1;
-
-  const serverPage = currentPage - 1;
-
-  const handlePageChange = (page: number) => {
-    router.push(`/all/${page}`);
-  };
-
-  const { data, isLoading } = useQuery<CampaignApiResponse>({
-    queryKey: [
-      campaignKeys.byCategoryPaginated(
-        campaignCategory,
-        'popular',
-        campaignLanguage,
-        serverPage,
-        12
-      ),
-    ],
-    queryFn: () =>
-      getCampaignsByCategory({
-        section: 'KBeauty',
-        category: campaignCategory,
-        page: serverPage,
-        size: 12,
-        locale: campaignLanguage,
-      }),
-  });
-
-  const campaigns = data?.data?.campaigns || [];
-
-  const totalPages = data?.data?.pageInfo
-    ? Math.ceil((data.data.pageInfo.numberOfElements || 0) / 12)
-    : 1;
+  const {
+    campaignCategory,
+    setCampaignCategory,
+    campaignLanguage,
+    setCampaignLanguage,
+    campaigns,
+    isLoading,
+    currentPage,
+    totalPages,
+    handlePageChange,
+  } = useCampaignsPaginated();
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -19,25 +19,27 @@ import { CampaignApiResponse } from './home-section-campaign';
 
 export default function CampaignAll() {
   const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
+  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
 
   const router = useRouter();
   const params = useParams();
   const pageParam = Array.isArray(params.page) ? params.page[0] : params.page;
+
   const currentPage = pageParam ? parseInt(pageParam) : 1;
 
-  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
+  const serverPage = currentPage - 1;
 
   const handlePageChange = (page: number) => {
     router.push(`/all/${page}`);
   };
 
-  const { data } = useQuery<CampaignApiResponse>({
+  const { data, isLoading } = useQuery<CampaignApiResponse>({
     queryKey: [
       campaignKeys.byCategoryPaginated(
         campaignCategory,
         'popular',
         campaignLanguage,
-        currentPage - 1,
+        serverPage,
         12
       ),
     ],
@@ -45,14 +47,17 @@ export default function CampaignAll() {
       getCampaignsByCategory({
         section: 'KBeauty',
         category: campaignCategory,
-        page: currentPage - 1,
+        page: serverPage,
         size: 12,
         locale: campaignLanguage,
       }),
   });
 
-  // TODO API 응답 필드 보고 카테고리 필터 추가 후 렌더링
-  const campaigns = data?.data?.campaigns?.slice(0, 6) || [];
+  const campaigns = data?.data?.campaigns || [];
+
+  const totalPages = data?.data?.pageInfo
+    ? Math.ceil((data.data.pageInfo.numberOfElements || 0) / 12)
+    : 1;
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">
@@ -63,11 +68,11 @@ export default function CampaignAll() {
         setCampaignLanguage={setCampaignLanguage}
         showSeeMore={false}
       />
-      <CampaignGrid campaigns={campaigns} />
+      <CampaignGrid campaigns={campaigns} isLoading={isLoading} />
       <div className="mb-[6.4rem] mt-[4.8rem] flex w-full items-center justify-center">
         <Pagenation
           currentPage={currentPage}
-          totalPages={20}
+          totalPages={totalPages}
           handlePageChange={handlePageChange}
         />
       </div>

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -8,16 +8,15 @@ import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { CATEGORY_NAME_NEW } from 'constants/category';
 import { useRouter } from 'i18n/navigation';
 import { campaignDummyData } from 'mocks/campaignData';
+import { LanguageKey } from 'types/language';
 
 import { Pagenation } from '@lococo/design-system/pagenation';
 
 import { CategoryKey } from '../../../../../types/category';
 import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
-import { LocaleType } from './campaign-language';
 
 export default function CampaignAll() {
   const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
@@ -27,7 +26,7 @@ export default function CampaignAll() {
   const pageParam = Array.isArray(params.page) ? params.page[0] : params.page;
   const currentPage = pageParam ? parseInt(pageParam) : 1;
 
-  const [campaignLanguage, setCampaignLanguage] = useState<LocaleType>('en');
+  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
 
   const handlePageChange = (page: number) => {
     router.push(`/all/${page}`);

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -2,14 +2,12 @@
 
 import React, { useState } from 'react';
 
-import { useLocale } from 'next-intl';
 import { useParams } from 'next/navigation';
 
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
 import { useRouter } from 'i18n/navigation';
-import { campaignDummyData } from 'mocks/campaignData';
 import { LanguageKey } from 'types/language';
 
 import { Pagenation } from '@lococo/design-system/pagenation';
@@ -17,6 +15,7 @@ import { Pagenation } from '@lococo/design-system/pagenation';
 import { CategoryKey } from '../../../../../types/category';
 import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
+import { CampaignApiResponse } from './home-section-campaign';
 
 export default function CampaignAll() {
   const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
@@ -32,15 +31,13 @@ export default function CampaignAll() {
     router.push(`/all/${page}`);
   };
 
-  const locale = useLocale();
-
-  const { data } = useQuery({
+  const { data } = useQuery<CampaignApiResponse>({
     queryKey: [
       campaignKeys.byCategoryPaginated(
         campaignCategory,
         'popular',
-        locale,
-        currentPage,
+        campaignLanguage,
+        currentPage - 1,
         12
       ),
     ],
@@ -48,13 +45,14 @@ export default function CampaignAll() {
       getCampaignsByCategory({
         section: 'KBeauty',
         category: campaignCategory,
-        page: currentPage,
+        page: currentPage - 1,
         size: 12,
-        locale: locale,
+        locale: campaignLanguage,
       }),
   });
 
   // TODO API 응답 필드 보고 카테고리 필터 추가 후 렌더링
+  const campaigns = data?.data?.campaigns?.slice(0, 6) || [];
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">
@@ -65,7 +63,7 @@ export default function CampaignAll() {
         setCampaignLanguage={setCampaignLanguage}
         showSeeMore={false}
       />
-      <CampaignGrid campaigns={campaignDummyData} />
+      <CampaignGrid campaigns={campaigns} />
       <div className="mb-[6.4rem] mt-[4.8rem] flex w-full items-center justify-center">
         <Pagenation
           currentPage={currentPage}

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -2,8 +2,10 @@
 
 import React, { useState } from 'react';
 
+import { useLocale } from 'next-intl';
 import { useParams } from 'next/navigation';
 
+import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
 import { useRouter } from 'i18n/navigation';
@@ -12,6 +14,8 @@ import { campaignDummyData } from 'mocks/campaignData';
 import { Pagenation } from '@lococo/design-system/pagenation';
 
 import { CategoryValue } from '../../../../../types/category';
+import { getCampaignsByCategory } from '../apis';
+import { campaignKeys } from '../query';
 import { LocaleType } from './campaign-language';
 
 export default function CampaignAll() {
@@ -28,6 +32,28 @@ export default function CampaignAll() {
   const handlePageChange = (page: number) => {
     router.push(`/all/${page}`);
   };
+
+  const locale = useLocale();
+
+  const { data } = useQuery({
+    queryKey: [
+      campaignKeys.byCategoryPaginated(
+        campaignCategory,
+        'popular',
+        locale,
+        currentPage,
+        12
+      ),
+    ],
+    queryFn: () =>
+      getCampaignsByCategory({
+        section: 'KBeauty',
+        category: campaignCategory,
+        page: currentPage,
+        size: 12,
+        locale: locale,
+      }),
+  });
 
   // TODO API 응답 필드 보고 카테고리 필터 추가 후 렌더링
 

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-all.tsx
@@ -8,19 +8,19 @@ import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
+import { CATEGORY_NAME_NEW } from 'constants/category';
 import { useRouter } from 'i18n/navigation';
 import { campaignDummyData } from 'mocks/campaignData';
 
 import { Pagenation } from '@lococo/design-system/pagenation';
 
-import { CategoryValue } from '../../../../../types/category';
+import { CategoryKey } from '../../../../../types/category';
 import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
 import { LocaleType } from './campaign-language';
 
 export default function CampaignAll() {
-  const [campaignCategory, setCampaignCategory] =
-    useState<CategoryValue>('ALL');
+  const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
 
   const router = useRouter();
   const params = useParams();

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-language.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-language.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
-import { LANGUAGES } from 'constants/language';
+import { LANGUAGE_KEYS } from 'constants/language';
 import { LanguageKey } from 'types/language';
 
 import {
@@ -40,7 +40,7 @@ export default function CampaignLanguage({
         </SelectTrigger>
 
         <SelectContent className="body4 mt-[1.6rem] w-[11rem]" align="center">
-          {Object.keys(LANGUAGES).map((lang) => (
+          {LANGUAGE_KEYS.map((lang) => (
             <SelectItem
               key={lang}
               value={lang}

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-language.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/campaign-language.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { LANGUAGES } from 'constants/language';
+import { LanguageKey } from 'types/language';
 
 import {
   SelectContent,
@@ -12,18 +13,16 @@ import {
 } from '@lococo/design-system/select';
 import { SvgArrowUp } from '@lococo/icons';
 
-export type LocaleType = (typeof LANGUAGES)[number]['value'];
-
 interface CampaignLanguageProps {
-  locale: LocaleType;
-  setLocale: (locale: LocaleType) => void;
+  locale: LanguageKey;
+  setLocale: (locale: LanguageKey) => void;
 }
 
 export default function CampaignLanguage({
   locale,
   setLocale,
 }: CampaignLanguageProps) {
-  const handleLanguageChange = (newValue: LocaleType) => {
+  const handleLanguageChange = (newValue: LanguageKey) => {
     setLocale(newValue);
   };
 
@@ -41,15 +40,15 @@ export default function CampaignLanguage({
         </SelectTrigger>
 
         <SelectContent className="body4 mt-[1.6rem] w-[11rem]" align="center">
-          {LANGUAGES.map((lang) => (
+          {Object.keys(LANGUAGES).map((lang) => (
             <SelectItem
-              key={lang.value}
-              value={lang.value}
+              key={lang}
+              value={lang}
               className="flex h-[4.4rem] w-[11rem] justify-center p-0 text-center"
               hover
-              onClick={() => handleLanguageChange(lang.value)}
+              onClick={() => handleLanguageChange(lang)}
             >
-              {lang.label}
+              {lang}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -10,7 +10,7 @@ import CampaignGrid from 'components/campaign/campaign-grid';
 import { campaignDummyData } from 'mocks/campaignData';
 import { CategoryValue } from 'types/category';
 
-import { getProductsByCategory } from '../apis';
+import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
 import { LocaleType } from './campaign-language';
 
@@ -32,7 +32,7 @@ export default function HomeSectionCampaign({
   const { data } = useQuery({
     queryKey: [campaignKeys.byCategory(campaignCategory, kindOfCard, locale)],
     queryFn: () =>
-      getProductsByCategory({
+      getCampaignsByCategory({
         section: kindOfCard,
         category: campaignCategory,
         page: 0,

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -7,7 +7,6 @@ import { useLocale } from 'next-intl';
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { campaignDummyData } from 'mocks/campaignData';
 import { CategoryValue } from 'types/category';
 
 import { getCampaignsByCategory } from '../apis';
@@ -17,6 +16,36 @@ import { LocaleType } from './campaign-language';
 interface HomeSectionCampaignProps {
   kindOfCard: 'KBeauty' | 'openingSoon';
   seeMore?: boolean;
+}
+
+export interface CampaignApiResponse {
+  success: boolean;
+  status: number;
+  message: string;
+  data: {
+    campaigns: Campaign[];
+    pageInfo: PageInfo;
+  };
+}
+
+interface PageInfo {
+  pageNumber: number;
+  pageSize: number;
+  numberOfElements: number;
+  isLast: boolean;
+}
+
+export interface Campaign {
+  campaignId: number;
+  campaignType: string;
+  language: string;
+  brandName: string;
+  campaignImageUrl: string;
+  campaignName: string;
+  applicantNumber: number;
+  recruitmentNumber: number;
+  endTime: string;
+  chipStatus: 'disabled' | 'default' | 'approved' | 'declined' | 'progress';
 }
 
 export default function HomeSectionCampaign({
@@ -29,10 +58,10 @@ export default function HomeSectionCampaign({
 
   const locale = useLocale();
 
-  const { data } = useQuery({
+  const { data } = useQuery<CampaignApiResponse>({
     queryKey: [campaignKeys.byCategory(campaignCategory, kindOfCard, locale)],
-    queryFn: () =>
-      getCampaignsByCategory({
+    queryFn: async () =>
+      await getCampaignsByCategory({
         section: kindOfCard,
         category: campaignCategory,
         page: 0,
@@ -41,10 +70,10 @@ export default function HomeSectionCampaign({
       }),
   });
 
-  console.log(data);
+  console.log(data?.data?.campaigns);
 
-  // TODO kindOfCard로 api 호출 -> 위의 훅들 기반으로 호출하고 인자로 size 넘겨주기(여기선 6) + API 응답 필드 보고 카테고리 필터 추가
-  const campaigns = campaignDummyData?.slice(0, 6) || [];
+  // TODO 카테고리 필터 추가
+  const campaigns = data?.data?.campaigns?.slice(0, 6) || [];
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -2,16 +2,14 @@
 
 import { useState } from 'react';
 
-import { useLocale } from 'next-intl';
-
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { CategoryKey } from 'types/category';
+import { LanguageKey } from 'types/language';
+import { CategoryKey } from 'types/tab-category';
 
 import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
-import { LocaleType } from './campaign-language';
 
 interface HomeSectionCampaignProps {
   kindOfCard: 'KBeauty' | 'openingSoon';
@@ -53,19 +51,19 @@ export default function HomeSectionCampaign({
   seeMore = false,
 }: HomeSectionCampaignProps) {
   const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
-  const [campaignLanguage, setCampaignLanguage] = useState<LocaleType>('en');
-
-  const locale = useLocale();
+  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
 
   const { data } = useQuery<CampaignApiResponse>({
-    queryKey: [campaignKeys.byCategory(campaignCategory, kindOfCard, locale)],
+    queryKey: [
+      campaignKeys.byCategory(campaignCategory, kindOfCard, campaignLanguage),
+    ],
     queryFn: async () =>
       await getCampaignsByCategory({
         section: kindOfCard,
         category: campaignCategory,
         page: 0,
         size: 6,
-        locale,
+        locale: campaignLanguage,
       }),
   });
 

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -70,7 +70,9 @@ export default function HomeSectionCampaign({
   console.log(data?.data?.campaigns);
 
   // TODO 카테고리 필터 추가
-  const campaigns = data?.data?.campaigns?.slice(0, 6) || [];
+  const campaigns = data?.data?.campaigns
+    ? data.data.campaigns.slice(0, 6)
+    : undefined;
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -1,15 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-
-import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { LanguageKey } from 'types/language';
-import { CategoryKey } from 'types/tab-category';
 
-import { getCampaignsByCategory } from '../apis';
-import { campaignKeys } from '../query';
+import { useHomeCampaigns } from '../hooks/useCampain';
 
 interface HomeSectionCampaignProps {
   kindOfCard: 'KBeauty' | 'openingSoon';
@@ -50,28 +44,14 @@ export default function HomeSectionCampaign({
   kindOfCard,
   seeMore = false,
 }: HomeSectionCampaignProps) {
-  const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
-  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
-
-  const { data, isLoading } = useQuery<CampaignApiResponse>({
-    queryKey: [
-      campaignKeys.byCategory(campaignCategory, kindOfCard, campaignLanguage),
-    ],
-    queryFn: async () =>
-      await getCampaignsByCategory({
-        section: kindOfCard,
-        category: campaignCategory,
-        page: 0,
-        size: 6,
-        locale: campaignLanguage,
-      }),
-  });
-
-  console.log(data?.data?.campaigns);
-
-  const campaigns = isLoading
-    ? undefined
-    : data?.data?.campaigns?.slice(0, 6) || [];
+  const {
+    isLoading,
+    campaignCategory,
+    setCampaignCategory,
+    campaignLanguage,
+    setCampaignLanguage,
+    campaigns,
+  } = useHomeCampaigns(kindOfCard);
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -7,7 +7,7 @@ import { useLocale } from 'next-intl';
 import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
-import { CategoryValue } from 'types/category';
+import { CategoryKey } from 'types/category';
 
 import { getCampaignsByCategory } from '../apis';
 import { campaignKeys } from '../query';
@@ -52,8 +52,7 @@ export default function HomeSectionCampaign({
   kindOfCard,
   seeMore = false,
 }: HomeSectionCampaignProps) {
-  const [campaignCategory, setCampaignCategory] =
-    useState<CategoryValue>('ALL');
+  const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
   const [campaignLanguage, setCampaignLanguage] = useState<LocaleType>('en');
 
   const locale = useLocale();

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -53,7 +53,7 @@ export default function HomeSectionCampaign({
   const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
   const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
 
-  const { data } = useQuery<CampaignApiResponse>({
+  const { data, isLoading } = useQuery<CampaignApiResponse>({
     queryKey: [
       campaignKeys.byCategory(campaignCategory, kindOfCard, campaignLanguage),
     ],
@@ -70,9 +70,9 @@ export default function HomeSectionCampaign({
   console.log(data?.data?.campaigns);
 
   // TODO 카테고리 필터 추가
-  const campaigns = data?.data?.campaigns
-    ? data.data.campaigns.slice(0, 6)
-    : undefined;
+  const campaigns = isLoading
+    ? undefined
+    : data?.data?.campaigns?.slice(0, 6) || [];
 
   return (
     <div className="flex w-full flex-col gap-[1.6rem]">
@@ -83,7 +83,7 @@ export default function HomeSectionCampaign({
         setCampaignLanguage={setCampaignLanguage}
         showSeeMore={seeMore}
       />
-      <CampaignGrid campaigns={campaigns} />
+      <CampaignGrid campaigns={campaigns} isLoading={isLoading} />
     </div>
   );
 }

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -2,11 +2,16 @@
 
 import { useState } from 'react';
 
+import { useLocale } from 'next-intl';
+
+import { useQuery } from '@tanstack/react-query';
 import CampaignFilters from 'components/campaign/campaign-filter';
 import CampaignGrid from 'components/campaign/campaign-grid';
 import { campaignDummyData } from 'mocks/campaignData';
 import { CategoryValue } from 'types/category';
 
+import { getProductsByCategory } from '../apis';
+import { campaignKeys } from '../query';
 import { LocaleType } from './campaign-language';
 
 interface HomeSectionCampaignProps {
@@ -15,12 +20,28 @@ interface HomeSectionCampaignProps {
 }
 
 export default function HomeSectionCampaign({
-  // kindOfCard,
+  kindOfCard,
   seeMore = false,
 }: HomeSectionCampaignProps) {
   const [campaignCategory, setCampaignCategory] =
     useState<CategoryValue>('ALL');
   const [campaignLanguage, setCampaignLanguage] = useState<LocaleType>('en');
+
+  const locale = useLocale();
+
+  const { data } = useQuery({
+    queryKey: [campaignKeys.byCategory(campaignCategory, kindOfCard, locale)],
+    queryFn: () =>
+      getProductsByCategory({
+        section: kindOfCard,
+        category: campaignCategory,
+        page: 0,
+        size: 6,
+        locale,
+      }),
+  });
+
+  console.log(data);
 
   // TODO kindOfCard로 api 호출 -> 위의 훅들 기반으로 호출하고 인자로 size 넘겨주기(여기선 6) + API 응답 필드 보고 카테고리 필터 추가
   const campaigns = campaignDummyData?.slice(0, 6) || [];

--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -69,7 +69,6 @@ export default function HomeSectionCampaign({
 
   console.log(data?.data?.campaigns);
 
-  // TODO 카테고리 필터 추가
   const campaigns = isLoading
     ? undefined
     : data?.data?.campaigns?.slice(0, 6) || [];

--- a/apps/web/app/[locale]/(with-layout)/(home)/hooks/useCampain.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/hooks/useCampain.ts
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+
+import { useParams } from 'next/navigation';
+
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'i18n/navigation';
+import { LanguageKey } from 'types/language';
+import { CategoryKey } from 'types/tab-category';
+
+import { getCampaignsByCategory } from '../apis';
+import { CampaignApiResponse } from '../components/home-section-campaign';
+import { campaignKeys } from '../query';
+
+interface UseCampaignsBaseProps {
+  section: 'KBeauty' | 'openingSoon';
+  page?: number;
+  size?: number;
+  enablePagination?: boolean;
+}
+
+export const useCampaignsBase = ({
+  section,
+  page = 0,
+  size = 6,
+  enablePagination = false,
+}: UseCampaignsBaseProps) => {
+  const [campaignCategory, setCampaignCategory] = useState<CategoryKey>('ALL');
+  const [campaignLanguage, setCampaignLanguage] = useState<LanguageKey>('EN');
+
+  const router = useRouter();
+  const params = useParams();
+  const pageValue = Array.isArray(params.page) ? params.page[0] : params.page;
+  const currentPage =
+    enablePagination && pageValue ? parseInt(pageValue) || 1 : 1;
+  const serverPage = enablePagination ? currentPage - 1 : page;
+
+  const { data, isLoading } = useQuery<CampaignApiResponse>({
+    queryKey: [
+      enablePagination
+        ? campaignKeys.byCategoryPaginated(
+            campaignCategory,
+            'popular',
+            campaignLanguage,
+            serverPage,
+            size
+          )
+        : campaignKeys.byCategory(campaignCategory, section, campaignLanguage),
+    ],
+    queryFn: () =>
+      getCampaignsByCategory({
+        section,
+        category: campaignCategory,
+        page: serverPage,
+        size,
+        locale: campaignLanguage,
+      }),
+  });
+
+  const campaigns = data?.data?.campaigns || [];
+  const totalPages = data?.data?.pageInfo
+    ? Math.ceil((data.data.pageInfo.numberOfElements || 0) / size)
+    : 1;
+
+  const handlePageChange = (page: number) => {
+    if (enablePagination) {
+      router.push(`/all/${page}`);
+    }
+  };
+
+  return {
+    campaigns,
+    isLoading,
+    currentPage: enablePagination ? currentPage : 1,
+    totalPages,
+    campaignCategory,
+    setCampaignCategory,
+    campaignLanguage,
+    setCampaignLanguage,
+    handlePageChange,
+  };
+};
+
+export const useHomeCampaigns = (kindOfCard: 'KBeauty' | 'openingSoon') => {
+  const result = useCampaignsBase({
+    section: kindOfCard,
+    size: 6,
+    enablePagination: false,
+  });
+
+  return {
+    ...result,
+    campaigns: result.campaigns.slice(0, 6),
+  };
+};
+
+export const useCampaignsPaginated = () => {
+  return useCampaignsBase({
+    section: 'KBeauty',
+    size: 12,
+    enablePagination: true,
+  });
+};

--- a/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
@@ -10,12 +10,14 @@ export const campaignKeys = {
   byCategoryPaginated: (
     category: CategoryValue,
     section: string,
-    locale: string
+    locale: string,
+    page: number,
+    size: number
   ) =>
     [
       ...campaignKeys.lists(locale),
       'category',
       'paginated',
-      { category, section },
+      { category, section, page, size },
     ] as const,
 };

--- a/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
@@ -1,14 +1,14 @@
-import { CategoryValue } from 'types/category';
+import { CategoryKey } from 'types/category';
 
 export const campaignKeys = {
   all: ['campaigns'] as const,
   lists: (locale: string) => [...campaignKeys.all, 'list', locale] as const,
 
-  byCategory: (category: CategoryValue, section: string, locale: string) =>
+  byCategory: (category: CategoryKey, section: string, locale: string) =>
     [...campaignKeys.lists(locale), 'category', { category, section }] as const,
 
   byCategoryPaginated: (
-    category: CategoryValue,
+    category: CategoryKey,
     section: string,
     locale: string,
     page: number,

--- a/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
+++ b/apps/web/app/[locale]/(with-layout)/(home)/query/index.ts
@@ -1,0 +1,21 @@
+import { CategoryValue } from 'types/category';
+
+export const campaignKeys = {
+  all: ['campaigns'] as const,
+  lists: (locale: string) => [...campaignKeys.all, 'list', locale] as const,
+
+  byCategory: (category: CategoryValue, section: string, locale: string) =>
+    [...campaignKeys.lists(locale), 'category', { category, section }] as const,
+
+  byCategoryPaginated: (
+    category: CategoryValue,
+    section: string,
+    locale: string
+  ) =>
+    [
+      ...campaignKeys.lists(locale),
+      'category',
+      'paginated',
+      { category, section },
+    ] as const,
+};

--- a/apps/web/components/campaign/campaign-filter.tsx
+++ b/apps/web/components/campaign/campaign-filter.tsx
@@ -54,7 +54,7 @@ export default function CampaignFilters({
         />
         {showSeeMore && (
           <Link
-            href={'/all/0'}
+            href={'/all/1'}
             className="flex cursor-pointer items-center gap-[0.8rem] px-[3.2rem] py-[1.6rem]"
           >
             <p className="body1 font-[700]">See More</p>

--- a/apps/web/components/campaign/campaign-filter.tsx
+++ b/apps/web/components/campaign/campaign-filter.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import CampaignLanguage, {
-  LocaleType,
-} from 'app/[locale]/(with-layout)/(home)/components/campaign-language';
+import CampaignLanguage from 'app/[locale]/(with-layout)/(home)/components/campaign-language';
 import { CATEGORY_NAME_NEW } from 'constants/category';
+import { CATEGORY_KEYS } from 'constants/tab-category';
 import { Link } from 'i18n/navigation';
-import { CATEGORY_KEYS, CategoryKey } from 'types/category';
+import { LanguageKey } from 'types/language';
+import { CategoryKey } from 'types/tab-category';
 
 import { Tab, TabContainer } from '@lococo/design-system/tab';
 import { SvgAdd } from '@lococo/icons';
@@ -13,8 +13,8 @@ import { SvgAdd } from '@lococo/icons';
 interface CampaignFiltersProps {
   campaignCategory: CategoryKey;
   setCampaignCategory: (value: CategoryKey) => void;
-  campaignLanguage: LocaleType;
-  setCampaignLanguage: (value: LocaleType) => void;
+  campaignLanguage: LanguageKey;
+  setCampaignLanguage: (value: LanguageKey) => void;
   showSeeMore?: boolean;
 }
 

--- a/apps/web/components/campaign/campaign-filter.tsx
+++ b/apps/web/components/campaign/campaign-filter.tsx
@@ -54,7 +54,7 @@ export default function CampaignFilters({
         />
         {showSeeMore && (
           <Link
-            href={'/all/1'}
+            href={'/all/0'}
             className="flex cursor-pointer items-center gap-[0.8rem] px-[3.2rem] py-[1.6rem]"
           >
             <p className="body1 font-[700]">See More</p>

--- a/apps/web/components/campaign/campaign-filter.tsx
+++ b/apps/web/components/campaign/campaign-filter.tsx
@@ -3,15 +3,16 @@
 import CampaignLanguage, {
   LocaleType,
 } from 'app/[locale]/(with-layout)/(home)/components/campaign-language';
+import { CATEGORY_NAME_NEW } from 'constants/category';
 import { Link } from 'i18n/navigation';
-import { CATEGORY_VALUES, CategoryValue } from 'types/category';
+import { CATEGORY_KEYS, CategoryKey } from 'types/category';
 
 import { Tab, TabContainer } from '@lococo/design-system/tab';
 import { SvgAdd } from '@lococo/icons';
 
 interface CampaignFiltersProps {
-  campaignCategory: CategoryValue;
-  setCampaignCategory: (value: CategoryValue) => void;
+  campaignCategory: CategoryKey;
+  setCampaignCategory: (value: CategoryKey) => void;
   campaignLanguage: LocaleType;
   setCampaignLanguage: (value: LocaleType) => void;
   showSeeMore?: boolean;
@@ -36,13 +37,13 @@ export default function CampaignFilters({
   return (
     <div className="flex h-[5.6rem] w-full items-center justify-between">
       <TabContainer variant="horizontal">
-        {CATEGORY_VALUES.map((CATEGORY_VALUE) => (
+        {CATEGORY_KEYS.map((CATEGORY_KEY) => (
           <Tab
-            key={CATEGORY_VALUE}
-            label={CATEGORY_VALUE}
-            value={CATEGORY_VALUE}
-            selected={campaignCategory === CATEGORY_VALUE}
-            onClick={() => setCampaignCategory(CATEGORY_VALUE)}
+            key={CATEGORY_KEY}
+            label={CATEGORY_NAME_NEW[CATEGORY_KEY]}
+            value={CATEGORY_KEY}
+            selected={campaignCategory === CATEGORY_KEY}
+            onClick={() => setCampaignCategory(CATEGORY_KEY)}
           />
         ))}
       </TabContainer>

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -4,49 +4,53 @@ import { getChipVariantByDate } from 'components/card/utils/getChipVariantByDate
 
 interface CampaignGridProps {
   campaigns?: Campaign[];
+  isLoading?: boolean;
 }
 
-export default function CampaignGrid({ campaigns }: CampaignGridProps) {
-  return (
-    <div>
-      {campaigns ? (
-        campaigns.length > 0 ? (
-          <div className="grid min-h-[33.1rem] grid-cols-3 gap-x-[2.4rem] gap-y-[3.2rem]">
-            {campaigns.map((campaign) => (
-              <Card
-                key={campaign.campaignId}
-                endTime={campaign.endTime}
-                chipVariant={
-                  campaign.chipStatus
-                    ? campaign.chipStatus
-                    : getChipVariantByDate(campaign.endTime)
-                }
-                brandName={campaign.brandName}
-                campaignName={campaign.campaignName}
-                campaignType={campaign.campaignType}
-                recruitmentNumber={campaign.recruitmentNumber}
-                applicantNumber={campaign.applicantNumber}
-                campaignImageUrl={campaign.campaignImageUrl}
-                campaignId={campaign.campaignId}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="flex min-h-[33.1rem] items-center justify-center">
-            <div className="text-center">
-              <p className="title1 font-[700] text-pink-500">
-                No campaigns available
-              </p>
-            </div>
-          </div>
-        )
-      ) : (
-        <div className="flex min-h-[33.1rem] items-center justify-center">
-          <div className="text-center">
-            <p className="title1 font-[700] text-pink-500">Loading...</p>
-          </div>
+export default function CampaignGrid({
+  campaigns,
+  isLoading,
+}: CampaignGridProps) {
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[33.1rem] items-center justify-center">
+        <div className="text-center">
+          <p className="text-gray-400">Loading...</p>
         </div>
-      )}
+      </div>
+    );
+  }
+
+  if (!campaigns || campaigns.length === 0) {
+    return (
+      <div className="flex min-h-[33.1rem] items-center justify-center">
+        <div className="text-center">
+          <p className="text-lg text-gray-500">No campaigns available</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-[33.1rem] grid-cols-3 gap-x-[2.4rem] gap-y-[3.2rem]">
+      {campaigns.map((campaign) => (
+        <Card
+          key={campaign.campaignId}
+          endTime={campaign.endTime}
+          chipVariant={
+            campaign.chipStatus
+              ? campaign.chipStatus
+              : getChipVariantByDate(campaign.endTime)
+          }
+          brandName={campaign.brandName}
+          campaignName={campaign.campaignName}
+          campaignType={campaign.campaignType}
+          recruitmentNumber={campaign.recruitmentNumber}
+          applicantNumber={campaign.applicantNumber}
+          campaignImageUrl={campaign.campaignImageUrl}
+          campaignId={campaign.campaignId}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -15,7 +15,7 @@ export default function CampaignGrid({
     return (
       <div className="flex min-h-[33.1rem] items-center justify-center">
         <div className="text-center">
-          <p className="text-gray-400">Loading...</p>
+          <p className="title1 font-[700] text-pink-500">Loading...</p>
         </div>
       </div>
     );
@@ -25,7 +25,9 @@ export default function CampaignGrid({
     return (
       <div className="flex min-h-[33.1rem] items-center justify-center">
         <div className="text-center">
-          <p className="text-lg text-gray-500">No campaigns available</p>
+          <p className="title1 font-[700] text-pink-500">
+            No campaigns available
+          </p>
         </div>
       </div>
     );

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -1,41 +1,29 @@
+import { Campaign } from 'app/[locale]/(with-layout)/(home)/components/home-section-campaign';
 import Card from 'components/card/Card';
 import { getChipVariantByDate } from 'components/card/utils/getChipVariantByDate';
-import { UserApplicationState } from 'mocks/campaignData';
-
-interface Campaign {
-  campaignId: number;
-  dueDate: string;
-  userApplicationState: UserApplicationState;
-  brand: string;
-  title: string;
-  label: string;
-  maxApplicants: number;
-  currentApplicants: number;
-  productThumbnailSrc: string;
-}
 
 interface CampaignGridProps {
-  campaigns: Campaign[];
+  campaigns?: Campaign[];
 }
 
 export default function CampaignGrid({ campaigns }: CampaignGridProps) {
   return (
     <div className="grid grid-cols-3 gap-x-[2.4rem] gap-y-[3.2rem]">
-      {campaigns.map((campaign) => (
+      {campaigns?.map((campaign) => (
         <Card
           key={campaign.campaignId}
-          dueDate={campaign.dueDate}
+          endTime={campaign.endTime}
           chipVariant={
-            campaign.userApplicationState
-              ? campaign.userApplicationState
-              : getChipVariantByDate(campaign.dueDate)
+            campaign.chipStatus
+              ? campaign.chipStatus
+              : getChipVariantByDate(campaign.endTime)
           }
-          brand={campaign.brand}
-          title={campaign.title}
-          label={campaign.label}
-          maxApplicants={campaign.maxApplicants}
-          currentApplicants={campaign.currentApplicants}
-          productThumbnailSrc={campaign.productThumbnailSrc}
+          brandName={campaign.brandName}
+          campaignName={campaign.campaignName}
+          campaignType={campaign.campaignType}
+          recruitmentNumber={campaign.recruitmentNumber}
+          applicantNumber={campaign.applicantNumber}
+          campaignImageUrl={campaign.campaignImageUrl}
           campaignId={campaign.campaignId}
         />
       ))}

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -8,25 +8,45 @@ interface CampaignGridProps {
 
 export default function CampaignGrid({ campaigns }: CampaignGridProps) {
   return (
-    <div className="grid grid-cols-3 gap-x-[2.4rem] gap-y-[3.2rem]">
-      {campaigns?.map((campaign) => (
-        <Card
-          key={campaign.campaignId}
-          endTime={campaign.endTime}
-          chipVariant={
-            campaign.chipStatus
-              ? campaign.chipStatus
-              : getChipVariantByDate(campaign.endTime)
-          }
-          brandName={campaign.brandName}
-          campaignName={campaign.campaignName}
-          campaignType={campaign.campaignType}
-          recruitmentNumber={campaign.recruitmentNumber}
-          applicantNumber={campaign.applicantNumber}
-          campaignImageUrl={campaign.campaignImageUrl}
-          campaignId={campaign.campaignId}
-        />
-      ))}
+    <div>
+      {campaigns ? (
+        campaigns.length > 0 ? (
+          <div className="grid min-h-[33.1rem] grid-cols-3 gap-x-[2.4rem] gap-y-[3.2rem]">
+            {campaigns.map((campaign) => (
+              <Card
+                key={campaign.campaignId}
+                endTime={campaign.endTime}
+                chipVariant={
+                  campaign.chipStatus
+                    ? campaign.chipStatus
+                    : getChipVariantByDate(campaign.endTime)
+                }
+                brandName={campaign.brandName}
+                campaignName={campaign.campaignName}
+                campaignType={campaign.campaignType}
+                recruitmentNumber={campaign.recruitmentNumber}
+                applicantNumber={campaign.applicantNumber}
+                campaignImageUrl={campaign.campaignImageUrl}
+                campaignId={campaign.campaignId}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-[33.1rem] items-center justify-center">
+            <div className="text-center">
+              <p className="title1 font-[700] text-pink-500">
+                No campaigns available
+              </p>
+            </div>
+          </div>
+        )
+      ) : (
+        <div className="flex min-h-[33.1rem] items-center justify-center">
+          <div className="text-center">
+            <p className="title1 font-[700] text-pink-500">Loading...</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/card/BracketChip.tsx
+++ b/apps/web/components/card/BracketChip.tsx
@@ -4,7 +4,7 @@ import { formatBracketDate } from './utils/getChipVariantByDate';
 
 interface BracketChipProps {
   dueDate: string;
-  chipVariant: 'expired' | 'active' | 'approved' | 'declined' | 'progress';
+  chipVariant: 'disabled' | 'default' | 'approved' | 'declined' | 'progress';
   className?: string;
 }
 
@@ -14,8 +14,8 @@ export default function BracketChip({
   className,
 }: BracketChipProps) {
   const CHIP_COLOR = {
-    expired: 'bg-gray-500',
-    active: 'bg-pink-500',
+    disabled: 'bg-gray-500',
+    default: 'bg-pink-500',
     approved: 'bg-green',
     declined: 'bg-red',
     progress: 'bg-blue',

--- a/apps/web/components/card/Card.tsx
+++ b/apps/web/components/card/Card.tsx
@@ -11,31 +11,42 @@ import InfoChip from '../../../../packages/design-system/src/components/info-chi
 import BracketChip from './BracketChip';
 
 interface CardProps {
-  dueDate: string;
-  chipVariant: 'expired' | 'active' | 'approved' | 'declined' | 'progress';
-  brand: string;
-  title: string;
-  label: string;
-  maxApplicants: number;
-  currentApplicants: number;
-  productThumbnailSrc: string;
+  endTime: string;
+  chipVariant: 'disabled' | 'default' | 'approved' | 'declined' | 'progress';
+  brandName: string;
+  campaignName: string;
+  campaignType: string;
+  recruitmentNumber: number;
+  applicantNumber: number;
+  campaignImageUrl: string;
   campaignId: number;
   className?: string;
 }
 
 export default function Card({
-  dueDate,
-  brand,
-  title,
-  label,
-  maxApplicants,
-  currentApplicants,
-  productThumbnailSrc,
+  endTime,
+  brandName,
+  campaignName,
+  campaignType,
+  recruitmentNumber,
+  applicantNumber,
+  campaignImageUrl,
   campaignId,
   chipVariant,
   className,
 }: CardProps) {
   const card = useTranslations('card');
+
+  const isValidUrl = (url: string) => {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const fallbackImage = '/next.svg';
   return (
     <div
       className={cn(
@@ -46,25 +57,25 @@ export default function Card({
       <Image
         width={360}
         height={216}
-        src={productThumbnailSrc}
-        alt={`${title}${card('campaignThumbnailImage')}`}
+        src={isValidUrl(campaignImageUrl) ? campaignImageUrl : fallbackImage}
+        alt={`${campaignName}${card('campaignThumbnailImage')}`}
       />
       <BracketChip
-        dueDate={dueDate}
+        dueDate={endTime}
         chipVariant={chipVariant}
         className="absolute right-[1.6rem] top-[1.6rem]"
       />
       <div className="absolute bottom-0 flex h-[11.5rem] w-full flex-col justify-between bg-white p-[1.6rem] transition-all duration-300 group-hover:h-[17.9rem]">
         <div className="flex flex-col gap-[0.8rem]">
           <div>
-            <p className="body4">{brand}</p>
-            <p className="title3">{title}</p>
+            <p className="body4">{brandName}</p>
+            <p className="title3 truncate">{campaignName}</p>
           </div>
           <div className="flex items-center gap-[0.8rem]">
-            <InfoChip text={label} />
+            <InfoChip text={campaignType} />
             <InfoChip
               icon={true}
-              text={`${currentApplicants}/${maxApplicants}`}
+              text={`${applicantNumber}/${recruitmentNumber}`}
             />
           </div>
         </div>

--- a/apps/web/components/card/utils/getChipVariantByDate.ts
+++ b/apps/web/components/card/utils/getChipVariantByDate.ts
@@ -5,7 +5,7 @@ export const getChipVariantByDate = (dueDate: string) => {
 
   const today = dayjs();
 
-  return targetDate.isBefore(today, 'day') ? 'expired' : 'active';
+  return targetDate.isBefore(today, 'day') ? 'disabled' : 'default';
 };
 
 export const formatBracketDate = (dateString: string): string => {

--- a/apps/web/components/gnb/gnb-language.tsx
+++ b/apps/web/components/gnb/gnb-language.tsx
@@ -2,7 +2,10 @@
 
 import { useLocale } from 'next-intl';
 
-import { LANGUAGES } from 'constants/language';
+import {
+  GNB_LANGUAGES,
+  GNB_LANGUAGE_KEYS,
+} from 'constants/language';
 import { usePathname, useRouter } from 'i18n/navigation';
 
 import {
@@ -33,14 +36,14 @@ export default function GnbLanguage() {
         </SelectTrigger>
 
         <SelectContent className="body4 mt-[2rem] w-[8.4rem]" align="center">
-          {LANGUAGES.map((lang) => (
+          {GNB_LANGUAGE_KEYS.map((lang) => (
             <SelectItem
-              key={lang.value}
-              value={lang.value}
+              key={lang}
+              value={lang}
               className="flex h-[4.4rem] w-[8.4rem] justify-center p-0 text-center"
               hover
             >
-              {lang.label}
+              {GNB_LANGUAGES[lang]}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/constants/category.ts
+++ b/apps/web/constants/category.ts
@@ -65,5 +65,5 @@ export const CATEGORY_NAME_NEW = {
   ALL: 'ALL',
   SKINCARE: 'Skincare',
   SUNCARE: 'Suncare',
-  MAKE_UP: 'Makeup',
+  MAKEUP: 'Makeup',
 } as const;

--- a/apps/web/constants/language.ts
+++ b/apps/web/constants/language.ts
@@ -1,0 +1,15 @@
+export const LANGUAGE_KEYS = ['EN', 'ES', 'ALL'] as const;
+
+export const LANGUAGES = {
+  EN: 'Eng',
+  ES: 'Esn',
+  ALL: 'All',
+} as const;
+
+export const GNB_LANGUAGES = {
+  EN: 'Eng',
+  ES: 'Esn',
+  KO: 'Kor',
+} as const;
+
+export const GNB_LANGUAGE_KEYS = ['EN', 'ES', 'KO'] as const;

--- a/apps/web/constants/language.tsx
+++ b/apps/web/constants/language.tsx
@@ -1,5 +1,0 @@
-export const LANGUAGES = [
-  { value: 'en', label: 'Eng' },
-  { value: 'es', label: 'Esn' },
-  { value: 'ko', label: 'Kor' },
-] as const;

--- a/apps/web/constants/tab-category.ts
+++ b/apps/web/constants/tab-category.ts
@@ -1,0 +1,8 @@
+export const CATEGORY_KEYS = ['ALL', 'SKINCARE', 'SUNCARE', 'MAKEUP'] as const;
+
+export const CATEGORY_NAME = {
+  ALL: 'ALL',
+  SKINCARE: 'Skincare',
+  SUNCARE: 'Suncare',
+  MAKEUP: 'Makeup',
+} as const;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -16,6 +16,14 @@ const nextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/types/category.ts
+++ b/apps/web/types/category.ts
@@ -23,6 +23,8 @@ export type CategoryOptionEng =
 export type CategoryValue =
   (typeof CATEGORY_NAME_NEW)[keyof typeof CATEGORY_NAME_NEW];
 
+export type CategoryKey = keyof typeof CATEGORY_NAME_NEW;
+
 export const CATEGORY_KEYS = Object.keys(
   CATEGORY_NAME_NEW
 ) as (keyof typeof CATEGORY_NAME_NEW)[];

--- a/apps/web/types/language.ts
+++ b/apps/web/types/language.ts
@@ -1,0 +1,5 @@
+import { LANGUAGES } from 'constants/language';
+
+export type LanguageKey = keyof typeof LANGUAGES;
+
+export type LanguageValue = (typeof LANGUAGES)[keyof typeof LANGUAGES];

--- a/apps/web/types/tab-category.ts
+++ b/apps/web/types/tab-category.ts
@@ -1,0 +1,5 @@
+import { CATEGORY_NAME } from 'constants/tab-category';
+
+export type CategoryKey = keyof typeof CATEGORY_NAME;
+
+export type CategoryValue = (typeof CATEGORY_NAME)[keyof typeof CATEGORY_NAME];


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #357 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] 메인페이지 API 연동

## To Reviewer
- 사용하는 훅들을 `useCampaign.ts` 라는 파일에 커스텀 훅을 만들어 분리해두었습니다.
   - 메인 페이지와 더보기 페이지 모두 기본적으로 탭, 언어 선택하는 헤더와 여러개의 카드를 렌더링하는 구조로 이루어져있기 때문에 공통으로 사용되는 훅들이 많았지만 페이지네이션, 사이징, 섹션(popular, upcoming) 등 조금씩 다른 부분들이 있었어서 공통되는 부분과 페이지 특화된 부분을 분리해서 페이지 특화된 훅에서는 공통되는 훅의 내용을 조합하여 사용하도록 구성하여 중복 코드를 제거하였습니다.(React에서 권장하는 커스텀훅 패턴 - https://react.dev/learn/reusing-logic-with-custom-hooks)
<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->
