### PR TITLE
Refactor(web): SelectFormField에 서버 데이터 표시 기능 추가

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/home-address.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/home-address.tsx
@@ -27,6 +27,7 @@ export function HomeAddress({ form, locale }: HomeAddressProps) {
           required
           placeholder={t('countryPlaceholder')}
           options={countries}
+          value={form.watch('country')}
           onValueChange={(value) =>
             form.setValue('country', value, { shouldValidate: true })
           }

--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/personal-details.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/personal-details.tsx
@@ -40,6 +40,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
                 <Select
                   placeholder={t('monthPlaceholder')}
                   options={months}
+                  value={form.watch('birthMonth')}
                   onValueChange={(selectedLabel) => {
                     const selectedMonth = months.find(
                       (option) => option.label === selectedLabel
@@ -57,6 +58,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
                 <Select
                   placeholder={t('dayPlaceholder')}
                   options={days}
+                  value={form.watch('birthDay')}
                   onValueChange={(selectedLabel) => {
                     const selectedDay = days.find(
                       (option) => option.label === selectedLabel
@@ -74,6 +76,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
                 <Select
                   placeholder={t('yearPlaceholder')}
                   options={years}
+                  value={form.watch('birthYear')}
                   onValueChange={(selectedLabel) => {
                     const selectedYear = years.find(
                       (option) => option.label === selectedLabel
@@ -111,6 +114,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
             required
             placeholder={t('genderPlaceholder')}
             options={GENDERS}
+            value={form.watch('gender')}
             onValueChange={(value) =>
               form.setValue('gender', value, { shouldValidate: true })
             }
@@ -139,6 +143,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
                 <Select
                   placeholder={t('phoneCountryPlaceholder')}
                   options={countryCodes}
+                  value={form.watch('phoneCountryCode')}
                   onValueChange={(selectedLabel) => {
                     const selectedCountryCode = countryCodes.find(
                       (option) => option.label === selectedLabel
@@ -184,6 +189,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
             required
             placeholder={t('contentLanguagePlaceholder')}
             options={CONTENT_LANGUAGES}
+            value={form.watch('contentLanguage')}
             onValueChange={(value) =>
               form.setValue('contentLanguage', value, {
                 shouldValidate: true,

--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/skin-info.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/skin-info.tsx
@@ -39,6 +39,7 @@ export function SkinInfo({ form }: SkinInfoProps) {
             variant="reverse"
             placeholder={t('skinTypePlaceholder')}
             options={SKIN_TYPES}
+            value={form.watch('skinType')}
             onValueChange={(value) =>
               form.setValue('skinType', value, { shouldValidate: true })
             }
@@ -51,6 +52,7 @@ export function SkinInfo({ form }: SkinInfoProps) {
             required
             placeholder={t('skinTonePlaceholder')}
             options={SKIN_TONES}
+            value={form.watch('skinTone')}
             onValueChange={(value) =>
               form.setValue('skinTone', value, { shouldValidate: true })
             }

--- a/apps/web/components/forms/CreatorFormSections.tsx
+++ b/apps/web/components/forms/CreatorFormSections.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 import {
@@ -12,13 +13,23 @@ interface CreatorFormSectionsProps {
   form: UseFormReturn<CreatorSignupForm>;
   locale: string;
   onCheckAvailability: () => void;
+  userData?: Partial<CreatorSignupForm>;
 }
 
 export function CreatorFormSections({
   form,
   locale,
   onCheckAvailability,
+  userData,
 }: CreatorFormSectionsProps) {
+  const { reset } = form;
+
+  useEffect(() => {
+    if (userData) {
+      reset(userData);
+    }
+  }, [userData, reset]);
+
   return (
     <>
       <CommunityName

--- a/apps/web/components/forms/SelectFormField.tsx
+++ b/apps/web/components/forms/SelectFormField.tsx
@@ -19,6 +19,7 @@ interface SelectFormFieldProps {
   size?: 'small' | 'default';
   children?: React.ReactNode;
   variant?: 'default' | 'reverse';
+  value?: string;
 }
 
 export function SelectFormField({
@@ -32,6 +33,7 @@ export function SelectFormField({
   size = 'default',
   children,
   variant = 'default',
+  value,
 }: SelectFormFieldProps) {
   return (
     <div className={cn('flex items-center justify-between', className)}>
@@ -48,6 +50,11 @@ export function SelectFormField({
           <Select
             placeholder={placeholder}
             options={options!}
+            value={
+              value
+                ? options!.find((option) => option.value === value)?.label
+                : undefined
+            }
             onValueChange={(selectedLabel) => {
               const selectedOption = options!.find(
                 (option) => option.label === selectedLabel


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #367 

- SelectFormField 컴포넌트에 서버에서 받은 사용자의 정보를 보여주기 위해 (정보 수정 페이지)
   사용자 데이터가 Select 필드들에 보여지도록 개선하였습니다. 

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->


- [X] SelectFormField 컴포넌트 value prop 추가
  - `apps/web/components/forms/SelectFormField.tsx`
  - value?: string prop 추가
  - value prop을 받아서 해당하는 label을 찾아 Select 컴포넌트에 전달
  - value가 없으면 undefined를 전달하여 placeholder 표시(회원가입시)
  - 서버에서 받은 데이터를 Select 필드에 표시할 수 있도록 함

- [X] CreatorFormSections에 userData prop 추가 및 폼 리셋 기능 구현
  - `apps/web/components/forms/CreatorFormSections.tsx`
  - userData?: Partial<CreatorSignupForm> prop 추가
  - useEffect를 사용하여 userData가 있을 때 form.reset(userData) 호출
  - 서버에서 받은 데이터로 폼 필드들을 자동으로 채움

- [X] 각 Select 컴포넌트들에 value prop 추가

## To Reviewer
- 회원가입 페이지: userData가 undefined이므로 Select 필드들이 비어있음 (placeholder 표시)
- 정보 수정 페이지: userData가 서버 데이터이므로 Select 필드들이 미리 채워짐 (선택된 값의 라벨 표시)
- form.watch()란: React Hook Form의 실시간 필드 감시 기능으로, 필드 값이 변경될 때마다 컴포넌트가 리렌더링됨



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입(크리에이터) 폼의 여러 선택 항목이 폼 상태와 완전히 동기화되어, 선택한 값과 초기값이 정확히 반영됩니다.
  - 제공된 사용자 정보가 있을 경우, 폼이 자동으로 해당 정보로 미리 채워지고 필요 시 초기화됩니다.
  - 국가, 생년월일, 성별, 전화 국가 코드, 선호 언어, 피부 타입/톤 등 선택 항목의 표시 값 일관성이 향상되어 입력 과정이 더 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->