### PR TITLE
fix(web):  SelectFormField 선택 값 미반영 오류 수정

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/home-address.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/home-address.tsx
@@ -20,7 +20,7 @@ export function HomeAddress({ form, locale }: HomeAddressProps) {
   const countries = countryNameOptions(locale);
 
   return (
-    <div className="mt-[4.8rem]">
+    <div className="mt-[4.8rem] w-full">
       <FormSection title={t('title')} description={t('description')}>
         <SelectFormField
           label={t('countryLabel')}

--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/personal-details.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/personal-details.tsx
@@ -31,7 +31,7 @@ export function PersonalDetails({ form }: PersonalDetailsProps) {
   const countryCodes = countryPhoneCodeOptions();
 
   return (
-    <div className="mt-[4.8rem]">
+    <div className="mt-[4.8rem] w-full">
       <FormSection title={t('title')} description={t('description')}>
         <div className="space-y-[1.6rem]">
           <SelectFormField label={t('birthLabel')} required>

--- a/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/skin-info.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/creator/components/skin-info.tsx
@@ -30,7 +30,7 @@ export function SkinInfo({ form }: SkinInfoProps) {
   }));
 
   return (
-    <div className="mt-[4.8rem]">
+    <div className="mt-[4.8rem] w-full">
       <FormSection title={t('title')} description={t('description')}>
         <div className="space-y-[1.6rem]">
           <SelectFormField

--- a/apps/web/constants/creator-options.ts
+++ b/apps/web/constants/creator-options.ts
@@ -1,28 +1,28 @@
 export const GENDERS = [
-  { label: 'Male', value: 'male' },
-  { label: 'Female', value: 'female' },
-  { label: 'Non-binary', value: 'non-binary' },
-  { label: 'Prefer not to say', value: 'prefer not to say' },
+  { label: 'Male', value: 'MALE' },
+  { label: 'Female', value: 'FEMALE' },
+  { label: 'Non-binary', value: 'NON_BINARY' },
+  { label: 'Prefer not to say', value: 'PREFER_NOT_TO_SAY' },
 ];
 
 export const CONTENT_LANGUAGES = [
-  { label: 'English', value: 'en' },
-  { label: 'Spanish', value: 'es' },
-  { label: 'English & Spanish', value: 'en_es' },
+  { label: 'English', value: 'ENGLISH' },
+  { label: 'Spanish', value: 'SPANISH' },
+  { label: 'English & Spanish', value: 'ENGLISH_AND_SPANISH' },
 ];
 
 export const SKIN_TYPES = [
-  { label: 'Normal', value: 'normal' },
-  { label: 'Dry', value: 'dry' },
-  { label: 'Oily', value: 'oily' },
-  { label: 'Combination', value: 'combination' },
-  { label: 'Sensitive', value: 'sensitive' },
-  { label: 'Others', value: 'others' },
+  { label: 'Normal', value: 'NORMAL' },
+  { label: 'Dry', value: 'DRY' },
+  { label: 'Oily', value: 'OILY' },
+  { label: 'Combination', value: 'COMBINATION' },
+  { label: 'Sensitive', value: 'SENSITIVE' },
+  { label: 'Others', value: 'OTHERS' },
 ];
 
 export const SKIN_TONE = [
-  { label: 'Shade 1', value: 'shade 1', color: '#F1DDD2' },
-  { label: 'Shade 2', value: 'shade 2', color: '#F4D6CB' },
-  { label: 'Shade 3', value: 'shade 3', color: '#EBC9BA' },
-  { label: 'Shade 4', value: 'shade 4', color: '#EDCBBC' },
+  { label: 'Shade 1', value: 'SHADE_1', color: '#F1DDD2' },
+  { label: 'Shade 2', value: 'SHADE_2', color: '#F4D6CB' },
+  { label: 'Shade 3', value: 'SHADE_3', color: '#EBC9BA' },
+  { label: 'Shade 4', value: 'SHADE_4', color: '#EDCBBC' },
 ];

--- a/apps/web/utils/birth-date-options.ts
+++ b/apps/web/utils/birth-date-options.ts
@@ -7,7 +7,7 @@ export const birthDateOptions = () => {
     const month = i + 1;
     return {
       label: `${month.toString().padStart(2, '0')}`,
-      value: `${month}`,
+      value: `${month.toString().padStart(2, '0')}`,
     };
   });
 
@@ -15,7 +15,7 @@ export const birthDateOptions = () => {
     const day = i + 1;
     return {
       label: `${day.toString().padStart(2, '0')}`,
-      value: `${day}`,
+      value: `${day.toString().padStart(2, '0')}`,
     };
   });
 

--- a/apps/web/utils/country-options.ts
+++ b/apps/web/utils/country-options.ts
@@ -32,7 +32,7 @@ export const countryPhoneCodeOptions = () => {
       countryCode,
       callingCode: getCountryCallingCode(countryCode),
       label: `+${getCountryCallingCode(countryCode)}`,
-      value: getCountryCallingCode(countryCode),
+      value: `+${getCountryCallingCode(countryCode)}`,
     }))
     .filter((item) => {
       if (uniqueCallingCodes.has(item.callingCode)) {


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #

- SelectFormField 컴포넌트에서 새로운 옵션을 선택시 라벨에 반영되지 않는 문제와 클라이언트에서 보내는 값과 서버의 응답 형식이 달라서 
  해당 부분 서버 담당자님과 논의를 통해 형식을 수정하였습니다. 


## Tasks
- [X] birth-date-options와 country-options 수정
  * `birth-date-options.ts`: months, days의 value를 label과 같게 수정
  * `country-options.ts`: countryPhoneCodeOptions의 value를 label과 같게 수정

- [X] 옵션 value와 서버 응답 형식 통일
  * `apps/web/constants/creator-options.ts`
  * ENDERS: value를 서버 형식에 맞게 수정 ('male' → 'MALE')
  * ONTENT_LANGUAGES: value를 서버 형식에 맞게 수정 ('en' → 'ENGLISH')
  * SKIN_TYPES: value를 서버 형식에 맞게 수정 ('normal' → 'NORMAL')
  * SKIN_TONE: value를 서버 형식에 맞게 수정 ('shade 1' → 'SHADE_1')
  * -> 서버 응답 데이터와 옵션 value가 정확히 매칭되도록 함

## To Reviewer
**<Select 값이 선택되지 않은 이유 및 해결>**
```
- 원인: SelectFormField는 내부에서 value를 label로 변환하지만, 직접 사용하는 Select 컴포넌트는 label을 기대함
- 해결: Select 컴포넌트에 value를 label로 변환하는 로직 추가

- 원인: 옵션 value와 서버 응답 형식 불일치, 서버에서 "MALE"로 응답하지만 옵션의 value는 "male"이어서 매칭 X
- 해결: 옵션의 value를 서버 형식에 맞게 수정
```

+ select 옵션들에 다국어가 적용되지 않은 상태입니다. api 연동하면서 처리하겠습니다!

## Screenshot

https://github.com/user-attachments/assets/9c0da8a4-d415-4886-a70b-289869ad4e61




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 국가 전화 코드 선택 값에 ‘+’가 추가되어 라벨과 값의 일관성이 개선되었습니다.
  * 생년월일 입력의 월·일 값이 두 자리(01–12, 01–31)로 표준화되어 포맷 일치와 검증 안정성이 향상되었습니다.
* 리팩터링
  * 생성자 관련 선택 옵션의 내부 값 표기를 대문자/정규화했습니다(라벨 변경 없음).
* 스타일/UI
  * 일부 회원가입 폼 섹션의 외부 컨테이너에 전체 너비(w-full) 클래스가 적용되어 레이아웃 폭이 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->