### PR TITLE
Fix(web): 임시저장 이미지 담는 변수 초기화 조건 추가

### DIFF
--- a/apps/web/components/campaign/campaign-upload-media.tsx
+++ b/apps/web/components/campaign/campaign-upload-media.tsx
@@ -50,18 +50,30 @@ export default function CampaignUploadMedia() {
 
   // 초기 로드 시 서버에서 제공받은 저장된만 existing으로 설정
   useEffect(() => {
-    if (!isThumbnailInitialized && currentThumbnailUrls.length > 0) {
+    if (
+      !isThumbnailInitialized &&
+      currentThumbnailUrls.length > 0 &&
+      thumbnailPreviewFiles.length === 0
+    ) {
       setExistingThumbnailUrls(currentThumbnailUrls.map((img) => img.url));
       setIsThumbnailInitialized(true);
     }
-  }, [currentThumbnailUrls, isThumbnailInitialized]);
+  }, [
+    currentThumbnailUrls,
+    isThumbnailInitialized,
+    thumbnailPreviewFiles.length,
+  ]);
 
   useEffect(() => {
-    if (!isDetailInitialized && currentDetailUrls.length > 0) {
+    if (
+      !isDetailInitialized &&
+      currentDetailUrls.length > 0 &&
+      detailPreviewFiles.length === 0
+    ) {
       setExistingDetailUrls(currentDetailUrls.map((img) => img.url));
       setIsDetailInitialized(true);
     }
-  }, [currentDetailUrls, isDetailInitialized]);
+  }, [currentDetailUrls, isDetailInitialized, detailPreviewFiles.length]);
 
   const handleRemoveExistingThumbnail = (index: number) => {
     const updatedExisting = existingThumbnailUrls.filter((_, i) => i !== index);

--- a/apps/web/components/campaign/campaign-upload-media.tsx
+++ b/apps/web/components/campaign/campaign-upload-media.tsx
@@ -33,8 +33,6 @@ export default function CampaignUploadMedia() {
     []
   );
   const [existingDetailUrls, setExistingDetailUrls] = useState<string[]>([]);
-  const [isThumbnailInitialized, setIsThumbnailInitialized] = useState(false);
-  const [isDetailInitialized, setIsDetailInitialized] = useState(false);
 
   const thumbnailFiles = watch('thumbnailFiles');
   const detailFiles = watch('detailFiles');
@@ -50,30 +48,16 @@ export default function CampaignUploadMedia() {
 
   // 초기 로드 시 서버에서 제공받은 저장된만 existing으로 설정
   useEffect(() => {
-    if (
-      !isThumbnailInitialized &&
-      currentThumbnailUrls.length > 0 &&
-      thumbnailPreviewFiles.length === 0
-    ) {
+    if (currentThumbnailUrls.length > 0 && thumbnailPreviewFiles.length === 0) {
       setExistingThumbnailUrls(currentThumbnailUrls.map((img) => img.url));
-      setIsThumbnailInitialized(true);
     }
-  }, [
-    currentThumbnailUrls,
-    isThumbnailInitialized,
-    thumbnailPreviewFiles.length,
-  ]);
+  }, [currentThumbnailUrls, thumbnailPreviewFiles.length]);
 
   useEffect(() => {
-    if (
-      !isDetailInitialized &&
-      currentDetailUrls.length > 0 &&
-      detailPreviewFiles.length === 0
-    ) {
+    if (currentDetailUrls.length > 0 && detailPreviewFiles.length === 0) {
       setExistingDetailUrls(currentDetailUrls.map((img) => img.url));
-      setIsDetailInitialized(true);
     }
-  }, [currentDetailUrls, isDetailInitialized, detailPreviewFiles.length]);
+  }, [currentDetailUrls, detailPreviewFiles.length]);
 
   const handleRemoveExistingThumbnail = (index: number) => {
     const updatedExisting = existingThumbnailUrls.filter((_, i) => i !== index);


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #438 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] 초기화 판별 조건 수정

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
useEffect에서 isThumbnailInitialized라는 변수로 초기 렌더링 flag를 만들고 초기 렌더링일 때만 서버에서 불러온 값을 미리보기용 이미지 배열에 담아두었는데, if문에 `currentThumbnailUrls.length > 0` 라는 조건이 함께 있어서 서버에서 불러온 이미지의 개수가 0개일 때는 setIsThumbnailInitialized(true)가 되지 않아 이후에 유저가 이미지 업로드를 할 때가 되어서야 true로 설정되면서 서버에 전송할 용도인 presignedURL까지 함께 src에 담겨서 2개의 이미지가 생성되는 버그가 있어서 기존 flag 형식으로 분기처리하던 방식에서 `thumbnailPreviewFiles.length === 0` 라는 변수를 추가하여 더 정확하게 판별하는 로직으로 변경하였습니다.

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 새 미리보기 파일이 없을 때 기존 썸네일/상세 이미지가 안정적으로 표시되지 않던 문제를 수정했습니다.
  - 초기 로딩 시 기존 이미지 누락 또는 갱신 타이밍 불일치를 개선했습니다.

- **개선**
  - 업로드 화면에서 기존 이미지 표시의 신뢰성과 일관성을 높였습니다.
  - 불필요한 초기화 제어를 제거해 예측 가능한 동작과 잠재적 깜빡임을 줄였습니다.
  - 기존 이미지를 교체하지 않는 경우에도 즉시 확인이 가능해 재업로드 필요성을 낮춥니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->