### PR TITLE
Feat(web): gnb 로그아웃 이벤트 추가 및 Card, 캠페인 생성 QA

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
+++ b/apps/web/app/[locale]/(with-layout)/(home)/components/home-section-campaign.tsx
@@ -62,7 +62,11 @@ export default function HomeSectionCampaign({
         setCampaignLanguage={setCampaignLanguage}
         showSeeMore={seeMore}
       />
-      <CampaignGrid campaigns={campaigns} isLoading={isLoading} />
+      <CampaignGrid
+        campaigns={campaigns}
+        isLoading={isLoading}
+        kindOfCard={kindOfCard}
+      />
     </div>
   );
 }

--- a/apps/web/app/[locale]/(with-layout)/brand/component/create-campaign/dynamic-inpt.tsx
+++ b/apps/web/app/[locale]/(with-layout)/brand/component/create-campaign/dynamic-inpt.tsx
@@ -25,6 +25,7 @@ export default function DynamicInput({ fieldName }: DynamicInputProps) {
             <Input
               className="h-[4rem] w-full"
               placeholder="text"
+              maxLength={100}
               {...register(`${fieldName}.${index}`)}
             />
             {isLastItem && (

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -6,11 +6,13 @@ import CampaignListEmpty from 'components/empty/campgin-list-empty';
 interface CampaignGridProps {
   campaigns?: Campaign[];
   isLoading?: boolean;
+  kindOfCard: 'KBeauty' | 'openingSoon';
 }
 
 export default function CampaignGrid({
   campaigns,
   isLoading,
+  kindOfCard,
 }: CampaignGridProps) {
   if (isLoading) {
     return <CampaignListEmpty emptyMessage="Loading..." />;
@@ -39,6 +41,7 @@ export default function CampaignGrid({
           campaignImageUrl={campaign.campaignImageUrl}
           campaignId={campaign.campaignId}
           hoverOption="hover"
+          isUpcoming={kindOfCard === 'openingSoon'}
         />
       ))}
     </div>

--- a/apps/web/components/campaign/campaign-grid.tsx
+++ b/apps/web/components/campaign/campaign-grid.tsx
@@ -6,7 +6,7 @@ import CampaignListEmpty from 'components/empty/campgin-list-empty';
 interface CampaignGridProps {
   campaigns?: Campaign[];
   isLoading?: boolean;
-  kindOfCard: 'KBeauty' | 'openingSoon';
+  kindOfCard?: 'KBeauty' | 'openingSoon';
 }
 
 export default function CampaignGrid({

--- a/apps/web/components/card/BracketChip.tsx
+++ b/apps/web/components/card/BracketChip.tsx
@@ -16,12 +16,14 @@ interface BracketChipProps {
     | 'WAITING_APPROVAL'
     | 'ACTIVE'
     | 'ALL';
+  isUpcoming?: boolean;
   className?: string;
 }
 
 export default function BracketChip({
   dueDate,
   chipVariant,
+  isUpcoming,
   className,
 }: BracketChipProps) {
   const CHIP_COLOR = {
@@ -61,7 +63,7 @@ export default function BracketChip({
        )`,
       }}
     >
-      {formatBracketDate(dueDate)}
+      {formatBracketDate(dueDate, isUpcoming)}
     </div>
   );
 }

--- a/apps/web/components/card/Card.tsx
+++ b/apps/web/components/card/Card.tsx
@@ -33,6 +33,7 @@ interface CardProps {
   campaignId: number;
   className?: string;
   hoverOption?: 'hover' | 'always';
+  isUpcoming?: boolean;
 }
 
 export default function Card({
@@ -47,6 +48,7 @@ export default function Card({
   chipVariant,
   className,
   hoverOption = 'hover',
+  isUpcoming = false,
 }: CardProps) {
   const card = useTranslations('card');
 
@@ -83,6 +85,7 @@ export default function Card({
           alt={`${campaignName}${card('campaignThumbnailImage')}`}
         />
         <BracketChip
+          isUpcoming={isUpcoming}
           dueDate={endTime}
           chipVariant={chipVariant}
           className="absolute right-[1.6rem] top-[1.6rem]"

--- a/apps/web/components/card/utils/getChipVariantByDate.ts
+++ b/apps/web/components/card/utils/getChipVariantByDate.ts
@@ -8,7 +8,10 @@ export const getChipVariantByDate = (dueDate: string) => {
   return targetDate.isBefore(today, 'day') ? 'disabled' : 'default';
 };
 
-export const formatBracketDate = (dateString: string): string => {
+export const formatBracketDate = (
+  dateString: string,
+  isUpComing?: boolean
+): string => {
   const date = dayjs(dateString);
-  return `~${date.format('MM/DD')}`;
+  return isUpComing ? `${date.format('MM/DD')}~` : `~${date.format('MM/DD')}`;
 };

--- a/apps/web/components/card/utils/getChipVariantByDate.ts
+++ b/apps/web/components/card/utils/getChipVariantByDate.ts
@@ -10,8 +10,8 @@ export const getChipVariantByDate = (dueDate: string) => {
 
 export const formatBracketDate = (
   dateString: string,
-  isUpComing?: boolean
+  isUpcoming?: boolean
 ): string => {
   const date = dayjs(dateString);
-  return isUpComing ? `${date.format('MM/DD')}~` : `~${date.format('MM/DD')}`;
+  return isUpcoming ? `${date.format('MM/DD')}~` : `~${date.format('MM/DD')}`;
 };

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -75,7 +75,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-pointer select-none items-center gap-2 data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
         'h-[4.4rem] justify-center border-b border-dashed border-pink-500 last:border-solid'
       )}

--- a/apps/web/hooks/use-auth.ts
+++ b/apps/web/hooks/use-auth.ts
@@ -3,9 +3,11 @@
 import { useEffect, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'i18n/navigation';
 import { checkIsLoggedIn, logout as logoutAction } from 'utils/action/auth';
 
 export function useAuth() {
+  const router = useRouter();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const queryClient = useQueryClient();
@@ -29,6 +31,7 @@ export function useAuth() {
     queryClient.removeQueries({ queryKey: ['auth'] });
     setIsLoggedIn(false);
     setIsLoggingOut(false);
+    router.push('/');
   };
 
   return {

--- a/apps/web/schema/create-campaign-schema.ts
+++ b/apps/web/schema/create-campaign-schema.ts
@@ -67,9 +67,24 @@ export const createCampaignSchema = z
     }),
 
     // 동적 입력 필드들
-    joinConditions: z.array(z.string().min(1, '조건을 입력해주세요')),
-    submitConditions: z.array(z.string().min(1, '조건을 입력해주세요')),
-    joinRewards: z.array(z.string().min(1, '보상을 입력해주세요')),
+    joinConditions: z.array(
+      z
+        .string()
+        .min(1, '조건을 입력해주세요')
+        .max(100, '최대 100자 이내로 입력해주세요')
+    ),
+    submitConditions: z.array(
+      z
+        .string()
+        .min(1, '조건을 입력해주세요')
+        .max(100, '최대 100자 이내로 입력해주세요')
+    ),
+    joinRewards: z.array(
+      z
+        .string()
+        .min(1, '보상을 입력해주세요')
+        .max(100, '최대 100자 이내로 입력해주세요')
+    ),
 
     // 플랫폼 선택
     firstContents: z.record(z.enum(SOCIAL_PLATFORMS), z.boolean()),


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #449 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] 로그아웃 시 메인으로 route.push
- [ ] Card 컴포넌트 upcoming 상태일 때 bracketChip 텍스트 반영
- [ ] 캠페인 생성 조건, 보상 필드 글자수 제한

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

## Screenshot

<!-- 스크린샷이 불필요한 작업이면 삭제해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 캠페인 그리드가 kindOfCard를 받아 K-Beauty / 오픈예정 카드 유형을 지원합니다.
  - Card와 BracketChip가 isUpcoming을 지원해 오픈예정 상태를 명확히 보여줍니다.
  - 로그아웃 시 자동으로 홈(/)으로 이동합니다.
  - 동적 입력 필드에 최대 100자 입력 제한이 적용되고, 입력 컴포넌트에도 maxLength=100이 추가되었습니다.

- 스타일
  - 드롭다운 메뉴 항목의 유틸리티 클래스 순서를 정리했습니다(동작 변화 없음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->