### PR TITLE
Feat(Web): 회원가입 페이지 엣지 케이스 QA

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -25,9 +25,11 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
 
   const getRoleRoutes = useCallback(
     () => ({
-      creator: () => router.replace(`/${locale}/sign-up/creator`),
-      brand: () => router.replace(`/${locale}/sign-up/brand`),
-      user: () => options?.onUserRoleSet?.(),
+      CREATOR: () => router.replace(`/${locale}/sign-up/creator`),
+      BRAND: () => router.replace(`/${locale}/sign-up/brand`),
+      CUSTOMER: () => router.replace(`/${locale}`),
+      ADMIN: () => router.replace(`/${locale}`),
+      PENDING: () => options?.onUserRoleSet?.(),
     }),
     [router, locale, options]
   );
@@ -41,7 +43,7 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
           router.replace(`/${locale}`);
           break;
         case 'INFO_REQUIRED':
-          if (role === 'user') {
+          if (role === 'CUSTOMER' || role === 'ADMIN') {
             router.replace(`/${locale}`);
           } else {
             const routeHandler = roleRoutes[role];
@@ -78,11 +80,20 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
   );
 
   const handleUrlRole = useCallback(async () => {
-    const urlRole = searchParams.get('role') as UserRole | null;
+    const urlRole = searchParams.get('role') as string | null;
     if (!urlRole) return false;
 
-    saveRoleToLocalStorage(urlRole);
-    await processRoleSetup(urlRole);
+    const roleMapping: Record<string, UserRole> = {
+      creator: 'CREATOR',
+      brand: 'BRAND',
+      user: 'CUSTOMER',
+    };
+
+    const mappedRole = roleMapping[urlRole.toLowerCase()];
+    if (!mappedRole) return false;
+
+    saveRoleToLocalStorage(mappedRole);
+    await processRoleSetup(mappedRole);
     return true;
   }, [searchParams, processRoleSetup]);
 

--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -7,6 +7,7 @@ import { apiRequest } from 'app/api/apiRequest';
 
 import { setUserRole } from '../utils/role-api';
 import {
+  UserRole,
   clearRoleFromLocalStorage,
   getRoleFromLocalStorage,
   saveRoleToLocalStorage,
@@ -15,8 +16,6 @@ import {
 interface UseRoleSetupOptions {
   onUserRoleSet?: () => void;
 }
-
-type UserRole = 'creator' | 'brand' | 'user';
 
 export const useRoleSetup = (options?: UseRoleSetupOptions) => {
   const router = useRouter();

--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -36,14 +36,29 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
     (loginStatus: string, role: UserRole) => {
       const roleRoutes = getRoleRoutes();
 
-      if (loginStatus === 'LOGIN') {
-        router.replace(`/${locale}`);
-      } else if (loginStatus === 'INFO_REQUIRED') {
-        const routeHandler = roleRoutes[role];
-        routeHandler?.();
-      } else {
-        const routeHandler = roleRoutes[role];
-        routeHandler?.();
+      switch (loginStatus) {
+        case 'LOGIN':
+          router.replace(`/${locale}`);
+          break;
+        case 'INFO_REQUIRED':
+          if (role === 'user') {
+            router.replace(`/${locale}`);
+          } else {
+            const routeHandler = roleRoutes[role];
+            routeHandler?.();
+          }
+          break;
+        case 'SNS_REQUIRED':
+          router.replace(`/${locale}/my-page/connect-sns`);
+          break;
+        case 'REGISTER': {
+          const signupRoute = roleRoutes[role];
+          signupRoute?.();
+          break;
+        }
+        default:
+          router.replace(`/${locale}`);
+          break;
       }
     },
     [router, locale, getRoleRoutes]

--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -55,17 +55,9 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
       try {
         const roleResponse = await setUserRole(role);
         handleLoginStatus(roleResponse.loginStatus, role);
-      } catch (error) {
-        if (
-          error &&
-          typeof error === 'string' &&
-          error.includes('이미 가입되었습니다.')
-        ) {
-          router.replace(`/${locale}/login-google`);
-        } else {
-          clearRoleFromLocalStorage();
-          router.replace(`/${locale}`);
-        }
+      } catch {
+        clearRoleFromLocalStorage();
+        router.replace(`/${locale}`);
       }
     },
     [router, locale, handleLoginStatus]

--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -1,47 +1,138 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useLocale } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { apiRequest } from 'app/api/apiRequest';
 
 import { setUserRole } from '../utils/role-api';
 import {
   clearRoleFromLocalStorage,
   getRoleFromLocalStorage,
+  saveRoleToLocalStorage,
 } from '../utils/role-storage';
 
 interface UseRoleSetupOptions {
   onUserRoleSet?: () => void;
 }
 
+type UserRole = 'creator' | 'brand' | 'user';
+
 export const useRoleSetup = (options?: UseRoleSetupOptions) => {
   const router = useRouter();
   const locale = useLocale();
+  const searchParams = useSearchParams();
+  const isSetupCompleted = useRef(false);
 
-  useEffect(() => {
-    const handleSetup = async () => {
-      const storedRole = getRoleFromLocalStorage();
-      if (storedRole) {
-        try {
-          await setUserRole(storedRole);
-          clearRoleFromLocalStorage();
+  const getRoleRoutes = useCallback(
+    () => ({
+      creator: () => router.replace(`/${locale}/sign-up/creator`),
+      brand: () => router.replace(`/${locale}/sign-up/brand`),
+      user: () => options?.onUserRoleSet?.(),
+    }),
+    [router, locale, options]
+  );
 
-          const roleRoutes = {
-            creator: () => router.replace(`/${locale}/sign-up/creator`),
-            brand: () => router.replace(`/${locale}/sign-up/brand`),
-            user: () => options?.onUserRoleSet?.(),
-          };
+  const handleLoginStatus = useCallback(
+    (loginStatus: string, role: UserRole) => {
+      const roleRoutes = getRoleRoutes();
 
-          const routeHandler = roleRoutes[storedRole];
-          if (routeHandler) {
-            routeHandler();
-          }
-        } catch {
+      if (loginStatus === 'LOGIN') {
+        router.replace(`/${locale}`);
+      } else if (loginStatus === 'INFO_REQUIRED') {
+        const routeHandler = roleRoutes[role];
+        routeHandler?.();
+      } else {
+        const routeHandler = roleRoutes[role];
+        routeHandler?.();
+      }
+    },
+    [router, locale, getRoleRoutes]
+  );
+
+  const processRoleSetup = useCallback(
+    async (role: UserRole) => {
+      try {
+        const roleResponse = await setUserRole(role);
+        handleLoginStatus(roleResponse.loginStatus, role);
+      } catch (error) {
+        if (
+          error &&
+          typeof error === 'string' &&
+          error.includes('이미 가입되었습니다.')
+        ) {
+          router.replace(`/${locale}/login-google`);
+        } else {
           clearRoleFromLocalStorage();
           router.replace(`/${locale}`);
         }
       }
+    },
+    [router, locale, handleLoginStatus]
+  );
+
+  const handleUrlRole = useCallback(async () => {
+    const urlRole = searchParams.get('role') as UserRole | null;
+    if (!urlRole) return false;
+
+    saveRoleToLocalStorage(urlRole);
+    await processRoleSetup(urlRole);
+    return true;
+  }, [searchParams, processRoleSetup]);
+
+  const handleLoggedInUser = useCallback(async () => {
+    const hasAccessToken = document.cookie.includes('AccessToken=');
+    if (!hasAccessToken) return false;
+
+    try {
+      const userInfo = await apiRequest<{
+        data?: { role?: string };
+      }>({
+        endPoint: '/api/auth/name',
+      });
+
+      if (!userInfo?.data?.role) return true;
+
+      const { role } = userInfo.data;
+
+      if (role === 'PENDING') {
+        const storedRole = getRoleFromLocalStorage();
+        if (storedRole) {
+          await processRoleSetup(storedRole);
+        } else {
+          options?.onUserRoleSet?.();
+        }
+      } else {
+        router.replace(`/${locale}`);
+      }
+    } catch {
+      const storedRole = getRoleFromLocalStorage();
+      if (storedRole) {
+        await processRoleSetup(storedRole);
+      } else {
+        router.replace(`/${locale}`);
+      }
+    }
+    return true;
+  }, [options, router, locale, processRoleSetup]);
+
+  const handleSignupMode = useCallback(async () => {
+    const storedRole = getRoleFromLocalStorage();
+    if (storedRole) {
+      await processRoleSetup(storedRole);
+    }
+  }, [processRoleSetup]);
+
+  useEffect(() => {
+    if (isSetupCompleted.current) return;
+
+    const handleSetup = async () => {
+      if (await handleUrlRole()) return;
+      if (await handleLoggedInUser()) return;
+      await handleSignupMode();
     };
 
     handleSetup();
-  }, [router, options, locale]);
+    isSetupCompleted.current = true;
+  }, [handleUrlRole, handleLoggedInUser, handleSignupMode]);
 };

--- a/apps/web/app/[locale]/(with-layout)/login-google/utils/role-api.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/utils/role-api.ts
@@ -14,9 +14,11 @@ export const setUserRole = async (
   role: UserRole
 ): Promise<RoleApiResponse['data']> => {
   const roleMapping: Record<UserRole, string> = {
-    creator: 'CREATOR',
-    brand: 'BRAND',
-    user: 'CUSTOMER',
+    PENDING: 'PENDING',
+    CUSTOMER: 'CUSTOMER',
+    CREATOR: 'CREATOR',
+    BRAND: 'BRAND',
+    ADMIN: 'ADMIN',
   };
 
   const response = await apiRequest<RoleApiResponse>({

--- a/apps/web/app/[locale]/(with-layout)/login-google/utils/role-api.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/utils/role-api.ts
@@ -1,18 +1,33 @@
+import { GoogleLoginResponse } from 'swagger-codegen/data-contracts';
+
 import { apiRequest } from '../../../../api/apiRequest';
 import { type UserRole } from './role-storage';
 
-export const setUserRole = async (role: UserRole): Promise<boolean> => {
+interface RoleApiResponse {
+  success: boolean;
+  status: number;
+  message: string;
+  data: GoogleLoginResponse;
+}
+
+export const setUserRole = async (
+  role: UserRole
+): Promise<RoleApiResponse['data']> => {
   const roleMapping: Record<UserRole, string> = {
     creator: 'CREATOR',
     brand: 'BRAND',
     user: 'CUSTOMER',
   };
 
-  const response = await apiRequest<{ success: boolean }>({
+  const response = await apiRequest<RoleApiResponse>({
     endPoint: '/api/auth/role',
     method: 'POST',
     data: { role: roleMapping[role] },
   });
 
-  return response.success;
+  if (!response.success) {
+    throw new Error('Role 설정에 실패했습니다.');
+  }
+
+  return response.data;
 };

--- a/apps/web/app/[locale]/(with-layout)/login-google/utils/role-storage.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/utils/role-storage.ts
@@ -1,4 +1,4 @@
-export type UserRole = 'creator' | 'brand' | 'user';
+export type UserRole = 'PENDING' | 'CUSTOMER' | 'CREATOR' | 'BRAND' | 'ADMIN';
 
 const ROLE_STORAGE_KEY = 'selectedRole';
 

--- a/apps/web/app/[locale]/(with-layout)/sign-up/components/select-role-modal.tsx
+++ b/apps/web/app/[locale]/(with-layout)/sign-up/components/select-role-modal.tsx
@@ -12,7 +12,7 @@ import {
 import { ModalHeader } from '@lococo/design-system/modal-header';
 import { SvgClose } from '@lococo/icons';
 
-type Role = 'creator' | 'brand' | 'user';
+type Role = 'CUSTOMER' | 'CREATOR' | 'BRAND';
 
 interface SelectRoleModalProps {
   open: boolean;
@@ -29,16 +29,16 @@ export function SelectRoleModal({
   const t = useTranslations('selectRoleModal');
 
   const roleTextMap: Record<Role, string> = {
-    creator: t('roles.creator'),
-    brand: t('roles.brand'),
-    user: t('roles.user'),
+    CREATOR: t('roles.creator'),
+    BRAND: t('roles.brand'),
+    CUSTOMER: t('roles.user'),
   };
 
   const handleSelectRole = (role: Role) => {
     onSelectRole(role);
     onOpenChange(false);
 
-    router.push(`/login-google?mode=signup&role=${role}`);
+    router.push(`/login-google?mode=signup&role=${role.toLowerCase()}`);
   };
 
   return (

--- a/apps/web/app/api/auth/google/login/route.ts
+++ b/apps/web/app/api/auth/google/login/route.ts
@@ -24,10 +24,14 @@ export async function GET(request: NextRequest) {
     if (response.ok) {
       try {
         const authData = await response.json();
-        const { accessToken } = authData.data || {};
+        const { accessToken, refreshToken } = authData.data || {};
 
         if (accessToken) {
           await setCookie('AccessToken', accessToken);
+
+          if (refreshToken) {
+            await setCookie('RefreshToken', refreshToken);
+          }
 
           return NextResponse.redirect(
             new URL('/login-google/loading', request.url)

--- a/apps/web/components/forms/SnsConnection.tsx
+++ b/apps/web/components/forms/SnsConnection.tsx
@@ -75,7 +75,7 @@ export function SnsConnection({
           />
         </div>
         {isPending ? (
-          <div className="flex flex-1 justify-center">
+          <div className="flex h-screen w-full items-center justify-center bg-white">
             <LoadingSvg />
           </div>
         ) : (

--- a/apps/web/components/forms/SnsConnection.tsx
+++ b/apps/web/components/forms/SnsConnection.tsx
@@ -75,7 +75,9 @@ export function SnsConnection({
           />
         </div>
         {isPending ? (
-          <LoadingSvg />
+          <div className="flex flex-1 justify-center">
+            <LoadingSvg />
+          </div>
         ) : (
           <>
             {platforms.map((platform, index) => (

--- a/apps/web/components/gnb/gnb-auth.tsx
+++ b/apps/web/components/gnb/gnb-auth.tsx
@@ -36,10 +36,19 @@ export default function GnbAuth() {
     setIsRoleModalOpen(true);
   };
 
-  const handleRoleSelect = (selectedRole: UserRole) => {
-    saveRoleToLocalStorage(selectedRole);
-    setIsRoleModalOpen(false);
-    router.push('/login-google?mode=signup');
+  const handleRoleSelect = (role: 'creator' | 'brand' | 'user') => {
+    const roleMapping: Record<string, UserRole> = {
+      creator: 'CREATOR',
+      brand: 'BRAND',
+      user: 'CUSTOMER',
+    };
+
+    const selectedRole = roleMapping[role];
+    if (selectedRole) {
+      saveRoleToLocalStorage(selectedRole);
+      setIsRoleModalOpen(false);
+      router.push('/login-google?mode=signup');
+    }
   };
 
   const handleRouteMyPage = () => {


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #442 
- 회원가입 페이지 엣지케이스 대응 작업 진행했습니다. 

## Tasks
- [x] 엣지케이스 처리 
  **<비정상적인 회원가입 플로우 (두 경우)>**
  - `INFO_NEEDED 사용자가 다시 회원가입 시도`
    - 새로운 Role 선택 → 구글 로그인 → 서버에서 Role 업데이트 → loginStatus: INFO_REQUIRED 응답 → Role에 따른 추가정보 입력 페이지로 이동
    - processRoleSetup() → handleLoginStatus() → Role별 라우팅
    
  - `LOGIN 사용자가 다시 회원가입 시도`
    - 기존 Role 유지 → loginStatus: LOGIN 응답 → 메인 페이지로 이동
    - processRoleSetup() → handleLoginStatus() → 메인 페이지 리다이렉트

  **<비정상적인 로그인 플로우 (두 경우)>**
  - `REGISTER 사용자가 로그인 시도`
      - loginStatus: REGISTER, role: PENDING → 로컬스토리지 Role 확인 → Role 선택 팝업 → URL 파라미터로 Role 전달 → 자동 API 호출
      -  handleLoggedInUser() → options?.onUserRoleSet?.() → handleUrlRole() → processRoleSetup()
      
  - `INFO_NEEDED 사용자가 로그인 시도`
    - loginStatus: INFO_NEEDED → 이전 Role의 추가정보 입력 화면으로 이동
    - processRoleSetup() → handleLoginStatus() → Role별 라우팅
  
  **<PENDING 상태 처리 (두 경우)>**
  - `PENDING + 로컬스토리지 Role 있음`
    - 로컬스토리지 Role로 processRoleSetup() 호출 → loginStatus에 따른 적절한 페이지로 이동
    -  handleLoggedInUser() → processRoleSetup() → handleLoginStatus()
  - `PENDING + 로컬스토리지 Role 없음`
    - Role 선택 팝업 표시 → 사용자 Role 선택 → URL 파라미터로 전달 → handleUrlRole()에서 자동 API 호출
    - options?.onUserRoleSet?.() → SelectRoleModal → handleUrlRole() → processRoleSetup()

## 참고자료
https://rightful-narwhal-db9.notion.site/269037058d20805d83f3e490231b1406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 구글 로그인에 RefreshToken 쿠키 지원 추가로 세션 지속성 향상
  - URL·로컬 저장된 역할을 한 번만 처리하는 역할 기반 가입/로그인 흐름 추가
- 버그 수정
  - 역할 처리 실패 시 명확한 오류 알림 및 안정적 라우팅 개선
- 리팩터
  - 역할 설정 흐름 모듈화 및 응답 처리 일관성 강화
  - 역할 타입 범위 확장으로 PENDING·ADMIN 등 추가 역할 지원
- 스타일
  - SNS 연동 로딩 표시 중앙 정렬 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->