### PR TITLE
fix(web): middleware.ts early return으로 인해 locale을 반환하지 않는 문제 해결

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/brand/layout.tsx
+++ b/apps/web/app/[locale]/(with-layout)/brand/layout.tsx
@@ -14,6 +14,7 @@ export default async function layout({
 }) {
   const t = await getTranslations('brandMyPageSideBar');
 
+
   const menuItems: MenuItem[] = [
     { label: t('myCampaign'), value: 'campaign' },
     { label: t('editProfile'), value: 'profile' },
@@ -21,6 +22,7 @@ export default async function layout({
     { label: t('checkApplicants'), value: 'applicants' },
     { label: t('checkContents'), value: 'contents-performance' },
   ];
+
   return (
     <div className="mx-auto flex w-[112rem]">
       <ClientSideBar menus={menuItems} defaultActiveMenu="campaign" />

--- a/apps/web/constants/language.ts
+++ b/apps/web/constants/language.ts
@@ -7,9 +7,9 @@ export const LANGUAGES = {
 } as const;
 
 export const GNB_LANGUAGES = {
-  EN: 'Eng',
-  ES: 'Esn',
-  KO: 'Kor',
+  en: 'Eng',
+  es: 'Esn',
+  ko: 'Kor',
 } as const;
 
-export const GNB_LANGUAGE_KEYS = ['EN', 'ES', 'KO'] as const;
+export const GNB_LANGUAGE_KEYS = ['en', 'es', 'ko'] as const;

--- a/packages/design-system/src/icons/fill/components/Alert.tsx
+++ b/packages/design-system/src/icons/fill/components/Alert.tsx
@@ -1,36 +1,10 @@
-import type { SVGProps } from 'react';
-
+import type { SVGProps } from "react";
 interface Props extends SVGProps<SVGSVGElement> {
   size?: number;
   fill?: string;
 }
 export function SvgAlert(props: Props) {
-  return (
-    <svg
-      width={props.size || 24}
-      height={props.size || 24}
-      viewBox="0 0 120 120"
-      fill={props.fill || 'currentColor'}
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      <rect width={120} height={120} rx={60} fill="#FFF1F6" />
-      <mask
-        id="mask0_5466_23186"
-        style={{
-          maskType: 'alpha',
-        }}
-        maskUnits="userSpaceOnUse"
-        x={30}
-        y={30}
-        width={60}
-        height={60}
-      >
-        <rect x={30} y={30} width={60} height={60} fill="#D9D9D9" />
-      </mask>
-      <g mask="url(#mask0_5466_23186)">
-        <path d="M60 82.5C58.625 82.5 57.4479 82.0104 56.4688 81.0312C55.4896 80.0521 55 78.875 55 77.5C55 76.125 55.4896 74.9479 56.4688 73.9688C57.4479 72.9896 58.625 72.5 60 72.5C61.375 72.5 62.5521 72.9896 63.5313 73.9688C64.5104 74.9479 65 76.125 65 77.5C65 78.875 64.5104 80.0521 63.5313 81.0312C62.5521 82.0104 61.375 82.5 60 82.5ZM55 67.5V37.5H65V67.5H55Z" />
-      </g>
-    </svg>
-  );
+  return <svg width={props.size || 24} height={props.size || 24} viewBox="0 0 120 120" fill={props.fill || "currentColor"} xmlns="http://www.w3.org/2000/svg" {...props}><rect width={120} height={120} rx={60} fill="#FFF1F6" /><mask id="mask0_5466_23186" style={{
+      maskType: "alpha"
+    }} maskUnits="userSpaceOnUse" x={30} y={30} width={60} height={60}><rect x={30} y={30} width={60} height={60} fill="#D9D9D9" /></mask><g mask="url(#mask0_5466_23186)"><path d="M60 82.5C58.625 82.5 57.4479 82.0104 56.4688 81.0312C55.4896 80.0521 55 78.875 55 77.5C55 76.125 55.4896 74.9479 56.4688 73.9688C57.4479 72.9896 58.625 72.5 60 72.5C61.375 72.5 62.5521 72.9896 63.5313 73.9688C64.5104 74.9479 65 76.125 65 77.5C65 78.875 64.5104 80.0521 63.5313 81.0312C62.5521 82.0104 61.375 82.5 60 82.5ZM55 67.5V37.5H65V67.5H55Z" /></g></svg>;
 }


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #471 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ]

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->
처음에 brand 페이지에서 loacle을 변경해도 url만 바뀌고 언어가 반영이 안 되길래 여러 방법을 시도해봤습니다...
1. `layout.tsx`에서 `getTranslations()` 함수에 params 전달하기 
   - 원래 getTranslations 함수는 locale 을 함께 입력받기도 합니다
```
   declare function getTranslations<NestedKey extends NamespaceKeys<Messages, NestedKeyOf<Messages>> = never>(opts?: {
    locale: Locale;
    namespace?: NestedKey;
}): Promise<ReturnType<typeof createTranslator<Messages, NestedKey>>>;
```
   - 하지만 기본적으로는 locale에서 값을 자동으로 가져와서 반영을 하는 방식입니다. 하지만 기존 방식대로  `  const t = await getTranslations('brandMyPageSideBar');` 와 같이 사용했을 땐  적용되지 않던 번역키가 locale을 함께 전달하니 적용되는 것을 확인할 수 있었습니다.
   - 여기서 getTranslations이 언어 설정을 바뀌어도 locale을 제대로 받아오지 못해서 기본값인 en을 가져오게 된다고 추측하였습니다.
2. 그래서 server component인 `layout.tsx`에서는 client component의 state와 같은 명확한 리렌더링 기준이 존재하지 않아 `gnb-language.tsx`에서 변경한 상태에 따라 리렌더링 되지 않아 언어 설정이 바로 반영되지 않는 것이라고 추측하였습니다.
   - 이 가설을 입증하기 위해서는 server component의 route 종류 중 빌드 타임에 한번만 실행되는 static route 임을 증명해야한다고 생각했고 이를 위해 콘솔 테스트와 빌드 결과를 확인해본 결과 dynamic route였다는 것을 알 수 있었습니다.
3. `request.ts`에서 requestLocale를 확인하기 위한 콘솔 테스트
```
export default getRequestConfig(async ({ requestLocale }) => {
  console.log('requestLocale:', requestLocale);
```
이를 통해 dynamic route로 locale을 제대로 받아올 수 있는 환경임에도 콘솔에서 undefined가 출력되는 것을 확인할 수 있었음.
4. intlMiddleware() 함수 내부에서 사용하는 AsyncStorage이 runtime에서 예상치 못한 동작을 할 수 있다는 사실을 알고 initialMiddleware를 먼저 호출하는 동작 방식 때문에 값이 바뀌나? -> 실행 순서 뒤로 변경해도 해결 안됨
5. early return으로 redirect 해야할 때 middleware의 실행을 차단하는 조건문을 발견
```
if (isAuthRequired) {
    if (!isLoggedIn) {
      const loginPath = `/${currentLocale}/login-google`;
      return NextResponse.redirect(new URL(loginPath, origin));
    } else {
      return NextResponse.next();
    }
  }
```
제거 후 성공...


추가로 앞으로 이처럼 의도하지 않았던 현상에 의해 언어 설정이 제대로 적용되지 않는 상황을 막기 위해 getTranslations 함수에 locale을 명시적으로 전달하는 방식도 논의해보면 좋을 것 같다고 생각했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 브랜드 페이지 레이아웃에 사이드바 메뉴 추가 및 기본 활성 메뉴(캠페인) 설정. 하위 콘텐츠가 레이아웃 내에서 정상 표시.
- 리팩터링
  - 인증/접근 제한 및 로케일 처리 흐름 정비로 로그인 리다이렉트와 언어 적용의 일관성 향상.
- 변경 사항
  - 언어 코드 표기를 소문자(en/es/ko)로 통일해 언어 선택 동작의 일관성 개선.
- 스타일
  - 아이콘 컴포넌트 포맷 정리(기능 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->