### PR TITLE
Fix(web): CUSTOMER 회원가입 시 크리에이터 전환 유도 모달 뛰우는 로직 수정

### DIFF
--- a/apps/web/app/[locale]/(with-layout)/login-google/components/RoleSetupHandler.tsx
+++ b/apps/web/app/[locale]/(with-layout)/login-google/components/RoleSetupHandler.tsx
@@ -4,16 +4,23 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { SelectRoleModal } from '../../../../../components/sign-up/select-role-modal';
 import { UserInductionModal } from '../../../../../components/sign-up/user-induction-modal';
 import { useRoleSetup } from '../hooks/useRoleSetup';
+import { type UserRole, saveRoleToLocalStorage } from '../utils/role-storage';
 
 export function RoleSetupHandler() {
   const router = useRouter();
   const [isInductionModalOpen, setIsInductionModalOpen] = useState(false);
+  const [isRoleModalOpen, setIsRoleModalOpen] = useState(false);
 
   useRoleSetup({
-    onUserRoleSet: () => {
-      setIsInductionModalOpen(true);
+    onUserRoleSet: (role?: UserRole) => {
+      if (role === 'PENDING') {
+        setIsRoleModalOpen(true);
+      } else {
+        setIsInductionModalOpen(true);
+      }
     },
   });
 
@@ -23,15 +30,38 @@ export function RoleSetupHandler() {
 
   const handleConfirm = () => {
     setIsInductionModalOpen(false);
+    saveRoleToLocalStorage('CREATOR');
     router.push('/sign-up/creator');
   };
 
+  const handleRoleSelect = (role: 'creator' | 'brand' | 'user') => {
+    const roleMapping: Record<string, UserRole> = {
+      creator: 'CREATOR',
+      brand: 'BRAND',
+      user: 'CUSTOMER',
+    };
+
+    const selectedRole = roleMapping[role];
+    if (selectedRole) {
+      saveRoleToLocalStorage(selectedRole);
+      setIsRoleModalOpen(false);
+      router.push('/login-google?mode=signup');
+    }
+  };
+
   return (
-    <UserInductionModal
-      open={isInductionModalOpen}
-      onOpenChange={setIsInductionModalOpen}
-      onCancel={handleCancel}
-      onConfirm={handleConfirm}
-    />
+    <>
+      <UserInductionModal
+        open={isInductionModalOpen}
+        onOpenChange={setIsInductionModalOpen}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+      />
+      <SelectRoleModal
+        open={isRoleModalOpen}
+        onOpenChange={setIsRoleModalOpen}
+        onSelectRole={handleRoleSelect}
+      />
+    </>
   );
 }

--- a/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
+++ b/apps/web/app/[locale]/(with-layout)/login-google/hooks/useRoleSetup.ts
@@ -14,7 +14,7 @@ import {
 } from '../utils/role-storage';
 
 interface UseRoleSetupOptions {
-  onUserRoleSet?: () => void;
+  onUserRoleSet?: (role?: UserRole) => void;
 }
 
 export const useRoleSetup = (options?: UseRoleSetupOptions) => {
@@ -29,7 +29,7 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
       BRAND: () => router.replace(`/${locale}/sign-up/brand`),
       CUSTOMER: () => router.replace(`/${locale}`),
       ADMIN: () => router.replace(`/${locale}`),
-      PENDING: () => options?.onUserRoleSet?.(),
+      PENDING: () => options?.onUserRoleSet?.('PENDING'),
     }),
     [router, locale, options]
   );
@@ -117,7 +117,14 @@ export const useRoleSetup = (options?: UseRoleSetupOptions) => {
         if (storedRole) {
           await processRoleSetup(storedRole);
         } else {
-          options?.onUserRoleSet?.();
+          options?.onUserRoleSet?.('PENDING');
+        }
+      } else if (role === 'CUSTOMER') {
+        const storedRole = getRoleFromLocalStorage();
+        if (storedRole === 'CUSTOMER') {
+          options?.onUserRoleSet?.('CUSTOMER');
+        } else {
+          router.replace(`/${locale}`);
         }
       } else {
         router.replace(`/${locale}`);


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #524 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] CUSTOMER 회원가입 시 크리에이터 전환 유도 모달 뛰우는 로직 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google 로그인 시 역할 선택 모달이 추가되어 사용자가 크리에이터, 브랜드 또는 일반 사용자 역할을 선택할 수 있습니다.
  * 선택한 역할이 자동으로 저장되어 향후 이용 시 유지됩니다.

* **개선 사항**
  * 역할 기반 라우팅 및 온보딩 플로우가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->