### PR TITLE
Feat(web): 아이디 가입 메시지 언어 번역 파일 다운로드

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -460,7 +460,7 @@
       "firstNameRequired": "First name is required.",
       "genderRequired": "Gender is required.",
       "idAvailabilityCheck": "Please check the ID availability.",
-      "idInvalidFormat": "This ID is unavailable. Please check the ID form.",
+      "idInvalidFormat": "Your username must be up to 15 characters and can only contain smallcase English letters, numbers, periods (.), and underscores (_).",
       "idMaxLength": "Use up to 15 characters.",
       "idRequired": "ID is required.",
       "lastNameMaxLength": "Use up to 20 characters.",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -460,7 +460,7 @@
       "firstNameRequired": "El nombre es obligatorio.",
       "genderRequired": "El género es obligatorio.",
       "idAvailabilityCheck": "Por favor, verifique la disponibilidad del ID.",
-      "idInvalidFormat": "Este ID no está disponible. Por favor, revisa el formato del ID.",
+      "idInvalidFormat": "Su nombre de usuario debe tener un máximo de 15 caracteres y solo puede contener letras minúsculas en inglés, números, puntos (.), y guiones bajos (_).",
       "idMaxLength": "Puede utilizar hasta 15 caracteres.",
       "idRequired": "El ID es obligatorio.",
       "lastNameMaxLength": "Puedes usar hasta 20 caracteres.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -460,7 +460,7 @@
       "firstNameRequired": "이름은 필수입니다. ",
       "genderRequired": "성별은 필수입니다. ",
       "idAvailabilityCheck": "ID 사용 가능 여부를 확인해주세요.",
-      "idInvalidFormat": "이 ID는 사용할 수 없습니다. ID 형식을 확인해 주세요.",
+      "idInvalidFormat": "사용자 이름은 최대 15자이며, 소문자 영어, 숫자, 마침표(.), 밑줄(_)만 포함할 수 있습니다.",
       "idMaxLength": "최대 15자까지 사용할 수 있습니다.",
       "idRequired": "ID는 필수 입력 항목입니다.",
       "lastNameMaxLength": "최대 20자까지 사용할 수 있습니다.",


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #546 

- 아이디 가입 안내 메시지 수정했습니다.

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [ ] ko, en, es 아이디 가입 메시지 언어 번역 파일 다운로드


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자명 형식 유효성 검사 오류 메시지를 개선했습니다. 새로운 메시지는 사용자명이 최대 15자이며, 소문자 영문자, 숫자, 마침표(.), 언더스코어(_)만 포함할 수 있다는 구체적인 형식 요구사항을 명확하게 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->