### PR TITLE
Fix(web): 마이페이지 클릭 시 마이페이지로 이동하지 않는 문제 해결

### DIFF
--- a/apps/web/components/gnb/gnb-auth.tsx
+++ b/apps/web/components/gnb/gnb-auth.tsx
@@ -46,7 +46,7 @@ export default function GnbAuth() {
 
   const isUserInfoEnabled = isLoggedIn === true && !isSignupPage(pathname);
 
-  const { data: userInfo } = useAuthInfo({
+  const { data: userInfo, refetch: refetchUserInfo } = useAuthInfo({
     enabled: isUserInfoEnabled,
   });
 
@@ -69,17 +69,19 @@ export default function GnbAuth() {
     }
   };
 
-  const handleRouteMyPage = () => {
-    if (!userInfo || userInfo?.role === 'PENDING') {
+  const handleRouteMyPage = async () => {
+    const freshUserInfo = userInfo ?? (await refetchUserInfo()).data;
+
+    if (!freshUserInfo || freshUserInfo?.role === 'PENDING') {
       setIsRoleModalOpen(true);
       return;
     }
 
-    if (userInfo?.role === 'BRAND') {
+    if (freshUserInfo?.role === 'BRAND') {
       router.push('/brand/campaign');
-    } else if (userInfo?.role === 'CREATOR') {
+    } else if (freshUserInfo?.role === 'CREATOR') {
       router.push('/my-page/my-campaign');
-    } else if (userInfo?.role === 'CUSTOMER') {
+    } else if (freshUserInfo?.role === 'CUSTOMER') {
       router.push('/my-page/my-campaign');
     }
   };


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #572 

- GNB 마이페이지 클릭 시 사용자 정보가 로딩되지 않은 상태에서 역할 선택 모달이 잘못 열리는 문제를 수정했습니다.
클릭 시 `userInfo`가 없으면 refetch를 통해 데이터를 확보한 뒤 역할을 판별하도록 변경했습니다.

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->
- [x] 마이페이지 클릭 시 `userInfo` 없을 때 refetch 후 처리
- [x] PENDING일 때만 역할 선택 모달 노출되도록 
- [x] 정상적인 role은 즉시 마이페이지로 라우팅

## To Reviewer
기존에 로그인 후 GNB 드롭다운의 마이페이지를 클릭하면 정상 유저임에도 역할 선택 모달이 떴습니다.
새로고침 후 다시 마이페이지를 누르면 정상 이동하는 현상이 있었습니다
문제의 원인과 해결 방법은 아래와 같습니다!

<원인>
- GNB에서 `userInfo`가 초기 로딩 전에 `undefined`인 경우를`PENDING`과 동일하게 처리하고 있어 잘못된 역할 선택 모달이 나타남
- 새로고침 후 정상 동작하는 이유는 `userInfo` 쿼리가 먼저 완료된 상태이기 때문


<해결 방향>
- 마이페이지 클릭 시 `userInfo`가 없으면 refetch 후 역할 판별하도록 수정
- PENDING일 때만 모달이 오픈되고 정상 role이면 라우팅
  - role이 정상(브랜드/크리에이터/유저)일 경우 마이페이지로 이동

## Screenshot

https://github.com/user-attachments/assets/fcaf70bd-f460-4930-a553-b09eb14bef5a


