### PR TITLE
Fix(admin): 이미지 업로드 API 서버 사이드로 변경

### DIFF
--- a/apps/admin/app/product-registration/api/index.ts
+++ b/apps/admin/app/product-registration/api/index.ts
@@ -3,6 +3,8 @@ import {
   ApiResponseProductBrandNameListResponse,
   ApiResponseAdminProductCreateResponse,
   AdminProductCreateRequest,
+  ApiResponseProductImageResponse,
+  ProductImagePresignedUrlRequest,
 } from '../../../../web/swagger-codegen/data-contracts';
 
 export const getProductBrandNames = async (
@@ -13,6 +15,17 @@ export const getProductBrandNames = async (
     endPoint: '/api/product-brand',
     method: 'GET',
     params,
+  });
+  return response;
+};
+
+export const getProductImagePresignedUrls = async (
+  data: ProductImagePresignedUrlRequest
+): Promise<ApiResponseProductImageResponse> => {
+  const response = await apiRequest<ApiResponseProductImageResponse>({
+    endPoint: '/api/admin/products/images',
+    method: 'POST',
+    data,
   });
   return response;
 };


### PR DESCRIPTION
<!-- 제목은 `Feat(작업 범위): {title}`형식으로 작성해주세요 -->
<!-- Reviewers, Assignees, Labels 등록했는지 확인해주세요 -->

## Summary

<!-- 이슈를 닫으면 안 되는 경우엔 close 키워드 삭제 후 이슈번호 등록해주세요 -->

> close: #591 

<!-- 작업한 내용에 대해 간단히 설명해주세요 -->

배포 환경에서 admin 상품 이미지 업로드 API 호출 시 발생하던 401 인증 오류를 수정하기 위해
클라이언트 사이드에서 쿠키를 읽는 방식에서 서버 사이드 인증 방식으로 변경하여 쿠키 도메인 불일치 문제를 해결했습니다.

## Tasks

<!-- 작업한 내용을 상세히 작성해주세요 -->

- [x] 클라이언트 사이드 쿠키 읽기 제거
  - `useProductImageUpload` 훅에서 `getClientCookie` 사용 제거
  - `getProductImagePresignedUrls`를 통해 서버 사이드 `apiRequest` 사용

## To Reviewer

<!-- reviewer가 확인해야 하는 부분이나 참고해야 하는 부분을 알려주세요 -->

### <주요 변경 사항>

1. **인증 방식 변경**
   - **이전**: 클라이언트 사이드에서 `getClientCookie('AccessToken')`로 쿠키를 읽어 직접 `fetch` 호출
   - **이후**: 서버 사이드 `apiRequest`를 통해 `getServerCookie`로 쿠키를 읽어 인증 처리

2. **문제 원인**
   - 배포 환경(`admin.lococo.beauty`)에서 쿠키가 `domain: 'lococo.beauty'`로 저장되어 클라이언트 사이드에서 읽을 수 없었음
   - 서버 사이드로 변경하여 브라우저가 HTTP 요청 시 쿠키를 자동으로 전송하도록 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제품 이미지 업로드 프로세스 개선 및 안정화

* **개선사항**
  * 제품 이미지 업로드 시 추가 메타데이터(표시 순서, 이미지 유형) 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->